### PR TITLE
Fix auto-assign logic and update CI configuration

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,18 +4,18 @@ on:
   pull_request:
     types: [opened]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   assign:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.addAssignees({
+            await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: ['**']
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -50,6 +50,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+
+      - name: Download modules
+        run: go mod download
 
       - name: Run tests
         run: go test -v -race -count=${{ env.TEST_COUNT }} -timeout 120s ./...


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve CI reliability and security. The main changes include broadening CI branch coverage, adjusting caching and dependency management for Go modules, and tightening permissions for the auto-assign workflow.

**CI Workflow Improvements:**

* The CI workflow now runs on all branches instead of just `main` and `develop`, ensuring that tests are executed for every branch push.
* The Go setup step disables caching (`cache: false`) to avoid potential issues with stale dependencies.
* A new step explicitly downloads Go modules using `go mod download`, ensuring dependencies are fetched before running tests.

**Auto-Assign Workflow Security:**

* The auto-assign workflow now only runs when the pull request originates from the same repository (not from forks), and permissions are set at the job level for better security.