### PR TITLE
feat: add WithOnTransportDrop and WithOnTransportRestore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- `WithOnTransportDrop(fn)` callback — fires when a connection's transport dies and the session enters the suspended state (requires `WithResumeWindow` > 0)
+- `WithOnTransportRestore(fn)` callback — fires when a suspended session resumes after a client reconnects within the resume window (requires `WithResumeWindow` > 0)
+
+### Changed
+
+- `WithResumeWindow` no longer enforces a 3-minute upper bound — any non-negative `time.Duration` is accepted
+
 ---
 
 ## [0.3.0] - 2026-03-13

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | `WithOnConnect(fn)`         | —                                    |
 | `WithOnMessage(fn)`         | —                                    |
 | `WithOnDisconnect(fn)`      | —                                    |
+| `WithOnTransportDrop(fn)`   | —                                    |
+| `WithOnTransportRestore(fn)`| —                                    |
 | `WithResumeWindow(d)`        | 0 (disabled)                         |
 | `WithHeartbeat(ping, pong)` | 10 s / 30 s                          |
 | `WithWriteWait(d)`          | 10 s                                 |

--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,20 @@
+package wspulse
+
+import "time"
+
+// clock abstracts time operations for testability.
+type clock interface {
+	AfterFunc(d time.Duration, f func()) *time.Timer
+	NewTicker(d time.Duration) *time.Ticker
+}
+
+// realClock delegates to the time package.
+type realClock struct{}
+
+func (realClock) AfterFunc(d time.Duration, f func()) *time.Timer {
+	return time.AfterFunc(d, f)
+}
+
+func (realClock) NewTicker(d time.Duration) *time.Ticker {
+	return time.NewTicker(d)
+}

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -157,7 +157,7 @@ layer.
 
 > **Type:** `WithResumeWindow` accepts a `time.Duration`.
 > `WithResumeWindow(30 * time.Second)` means a 30-second grace window.
-> Valid range: 0 (disabled) … 3 minutes.
+> Valid range: 0 (disabled) … no upper limit.
 
 ### Architecture
 

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -173,12 +173,12 @@ swapped in silently.
 ```
 [*] → Connected : handleRegister creates session + transport
 
-Connected → Suspended : transport dies, resumeWindow > 0 (start timer, buffer frames)
+Connected → Suspended : transport dies, resumeWindow > 0 (start timer, buffer frames, onTransportDrop fires)
 Connected → Closed    : transport dies, resumeWindow == 0 (onDisconnect fires)
 Connected → Closed    : Kick() or Close() (onDisconnect fires)
 Connected → Closed    : duplicate connectionID arrives (old session kicked, onDisconnect fires with ErrDuplicateConnectionID; new session created)
 
-Suspended → Connected : same connectionID reconnect (cancel timer, replay buffer, no callback)
+Suspended → Connected : same connectionID reconnect (cancel timer, replay buffer, onTransportRestore fires)
 Suspended → Closed    : timer expires (onDisconnect fires, session destroyed)
 Suspended → Closed    : Connection.Close() called (cancel timer, onDisconnect fires immediately)
 Suspended → Closed    : Kick() or server.Close() (cancel timer, onDisconnect fires immediately)
@@ -192,6 +192,7 @@ Closed → [*]
 WS1 connection drops
   → WS1 sends transportDiedMessage(session, err) to Hub
   → Hub detaches WS1, starts resumeWindow timer
+  → go onTransportDrop(session, err)
   → Session state = suspended, frames buffered to ringBuffer
 
 WS2 client reconnects with same connectionID
@@ -199,7 +200,7 @@ WS2 client reconnects with same connectionID
   → Hub cancels timer
   → Hub attaches WS2, drains ringBuffer to send channel
   → Hub starts writePump(WS2) + readPump(WS2)
-  → No onConnect / onDisconnect fired
+  → onTransportRestore fires; no onConnect / onDisconnect fired
 ```
 
 ### Resume Buffer

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,10 @@
+package wspulse
+
+// Clock exports the internal clock interface for testing only.
+type Clock = clock
+
+// WithClock returns a ServerOption that sets the clock. Test-only —
+// this file is only compiled during test builds.
+func WithClock(c Clock) ServerOption {
+	return func(cfg *serverConfig) { cfg.clock = c }
+}

--- a/export_test.go
+++ b/export_test.go
@@ -6,5 +6,8 @@ type Clock = clock
 // WithClock returns a ServerOption that sets the clock. Test-only —
 // this file is only compiled during test builds.
 func WithClock(c Clock) ServerOption {
+	if c == nil {
+		panic("wspulse: WithClock: clock must not be nil")
+	}
 	return func(cfg *serverConfig) { cfg.clock = c }
 }

--- a/hub.go
+++ b/hub.go
@@ -140,6 +140,9 @@ func (h *hub) handleRegister(message registerMessage) {
 			h.config.logger.Info("wspulse: session resumed",
 				zap.String("conn_id", message.connectionID),
 			)
+			if fn := h.config.onTransportRestore; fn != nil {
+				go fn(existing)
+			}
 			return
 
 		case stateConnected:
@@ -288,6 +291,9 @@ func (h *hub) handleTransportDied(message transportDiedMessage) {
 			zap.String("conn_id", target.id),
 			zap.Duration("resume_window", h.config.resumeWindow),
 		)
+		if fn := h.config.onTransportDrop; fn != nil {
+			go fn(target, message.err)
+		}
 		return
 	}
 

--- a/hub.go
+++ b/hub.go
@@ -3,7 +3,6 @@ package wspulse
 import (
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
@@ -266,7 +265,7 @@ func (h *hub) handleTransportDied(message transportDiedMessage) {
 			)
 			return
 		}
-		timer := time.AfterFunc(h.config.resumeWindow, func() {
+		timer := h.config.clock.AfterFunc(h.config.resumeWindow, func() {
 			select {
 			case h.graceExpired <- graceExpiredMessage{session: target, epoch: epoch}:
 			case <-h.done:

--- a/hub.go
+++ b/hub.go
@@ -136,13 +136,14 @@ func (h *hub) handleRegister(message registerMessage) {
 			// as stale and ignored by handleGraceExpired.
 			existing.cancelGraceTimer()
 
-			existing.attachWS(message.transport, h)
+			var onResume func()
+			if fn := h.config.onTransportRestore; fn != nil {
+				onResume = func() { fn(existing) }
+			}
+			existing.attachWS(message.transport, h, onResume)
 			h.config.logger.Info("wspulse: session resumed",
 				zap.String("conn_id", message.connectionID),
 			)
-			if fn := h.config.onTransportRestore; fn != nil {
-				go fn(existing)
-			}
 			return
 
 		case stateConnected:
@@ -185,7 +186,7 @@ func (h *hub) handleRegister(message registerMessage) {
 	h.connectionsByID[message.connectionID] = newSession
 	h.mu.Unlock()
 
-	newSession.attachWS(message.transport, h)
+	newSession.attachWS(message.transport, h, nil)
 
 	h.config.logger.Debug("wspulse: session connected",
 		zap.String("conn_id", message.connectionID),

--- a/options.go
+++ b/options.go
@@ -89,15 +89,36 @@ func WithOnDisconnect(fn func(Connection, error)) ServerOption {
 }
 
 // WithOnTransportDrop registers a callback invoked when a connection's
-// transport dies and the session enters the suspended state (resumeWindow > 0).
-// This does not fire when resumeWindow is 0. The callback runs in a separate goroutine.
+// underlying WebSocket transport dies (network drop, read timeout, or peer
+// close) and the session enters the suspended state because resumeWindow > 0.
+//
+// The error parameter carries the cause of the transport failure (e.g. an
+// i/o timeout from a missed Pong, or a close frame from the peer).
+//
+// This callback does NOT fire when:
+//   - resumeWindow is 0 (OnDisconnect fires directly instead).
+//   - the connection is removed via Kick() or Connection.Close()
+//     (OnDisconnect fires directly instead).
+//
+// The callback runs in a separate goroutine; it must be safe for concurrent use.
 func WithOnTransportDrop(fn func(Connection, error)) ServerOption {
 	return func(c *serverConfig) { c.onTransportDrop = fn }
 }
 
 // WithOnTransportRestore registers a callback invoked when a suspended session
-// resumes after a client reconnects within the resume window. This does not
-// fire when resumeWindow is 0. The callback runs in a separate goroutine.
+// resumes after a client reconnects with the same connectionID within the
+// resume window.
+//
+// When this fires, OnConnect and OnDisconnect are NOT called — the session
+// continues as if the transport had never dropped. Buffered frames are replayed
+// to the new transport before the callback is invoked.
+//
+// This callback does NOT fire when:
+//   - resumeWindow is 0 (session resumption is disabled).
+//   - the resume window expires before the client reconnects
+//     (OnDisconnect fires instead).
+//
+// The callback runs in a separate goroutine; it must be safe for concurrent use.
 func WithOnTransportRestore(fn func(Connection)) ServerOption {
 	return func(c *serverConfig) { c.onTransportRestore = fn }
 }

--- a/options.go
+++ b/options.go
@@ -92,8 +92,10 @@ func WithOnDisconnect(fn func(Connection, error)) ServerOption {
 // underlying WebSocket transport dies (network drop, read timeout, or peer
 // close) and the session enters the suspended state because resumeWindow > 0.
 //
-// The error parameter carries the cause of the transport failure (e.g. an
-// i/o timeout from a missed Pong, or a close frame from the peer).
+// The error parameter carries the cause of the transport failure when available
+// (e.g. an i/o timeout from a missed Pong, or a close frame from the peer).
+// For a normal or expected close, err may be nil, so callback implementations
+// must not assume it is always non-nil.
 //
 // This callback does NOT fire when:
 //   - resumeWindow is 0 (OnDisconnect fires directly instead).

--- a/options.go
+++ b/options.go
@@ -44,6 +44,7 @@ type serverConfig struct {
 	codec              Codec
 	checkOrigin        func(r *http.Request) bool
 	logger             *zap.Logger
+	clock              clock
 }
 
 func defaultConfig(connect ConnectFunc) *serverConfig {
@@ -58,6 +59,7 @@ func defaultConfig(connect ConnectFunc) *serverConfig {
 		codec:          JSONCodec,
 		checkOrigin:    func(*http.Request) bool { return true },
 		logger:         zap.NewNop(),
+		clock:          realClock{},
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -14,7 +14,6 @@ const (
 	maxWriteWait     = 30 * time.Second // WithWriteWait upper bound
 	maxMsgSizeBytes  = 64 << 20         // WithMaxMessageSize upper bound — 64 MiB
 	maxSendBufFrames = 4096             // WithSendBufferSize upper bound
-	maxResumeWindow  = 3 * time.Minute  // WithResumeWindow upper bound
 )
 
 // ConnectFunc authenticates an incoming HTTP upgrade request and provides the
@@ -194,13 +193,10 @@ func WithLogger(l *zap.Logger) ServerOption {
 // drops, the session is suspended for d before firing OnDisconnect. If the
 // same connectionID reconnects within that period, the session resumes
 // transparently.
-// Valid range: 0 (disabled) … 3m. Default is 0 (OnDisconnect fires immediately).
+// Valid range: 0 (disabled) … no upper limit. Default is 0 (OnDisconnect fires immediately).
 func WithResumeWindow(d time.Duration) ServerOption {
 	if d < 0 {
 		panic("wspulse: WithResumeWindow: duration must be non-negative")
-	}
-	if d > maxResumeWindow {
-		panic("wspulse: WithResumeWindow: duration exceeds maximum (3m)")
 	}
 	return func(c *serverConfig) { c.resumeWindow = d }
 }

--- a/options.go
+++ b/options.go
@@ -29,19 +29,21 @@ type ConnectFunc func(r *http.Request) (roomID, connectionID string, err error)
 type ServerOption func(*serverConfig) //nolint:revive
 
 type serverConfig struct {
-	connect        ConnectFunc
-	onConnect      func(Connection)
-	onMessage      func(Connection, Frame)
-	onDisconnect   func(Connection, error)
-	pingPeriod     time.Duration
-	pongWait       time.Duration
-	writeWait      time.Duration
-	maxMessageSize int64
-	sendBufferSize int
-	resumeWindow   time.Duration // session resume grace period as a time.Duration (e.g. 5*time.Minute); 0 = disabled
-	codec          Codec
-	checkOrigin    func(r *http.Request) bool
-	logger         *zap.Logger
+	connect            ConnectFunc
+	onConnect          func(Connection)
+	onMessage          func(Connection, Frame)
+	onDisconnect       func(Connection, error)
+	onTransportDrop    func(Connection, error)
+	onTransportRestore func(Connection)
+	pingPeriod         time.Duration
+	pongWait           time.Duration
+	writeWait          time.Duration
+	maxMessageSize     int64
+	sendBufferSize     int
+	resumeWindow       time.Duration // session resume grace period as a time.Duration (e.g. 5*time.Minute); 0 = disabled
+	codec              Codec
+	checkOrigin        func(r *http.Request) bool
+	logger             *zap.Logger
 }
 
 func defaultConfig(connect ConnectFunc) *serverConfig {
@@ -83,6 +85,20 @@ func WithOnMessage(fn func(Connection, Frame)) ServerOption {
 // expires without reconnection (not on every transport drop).
 func WithOnDisconnect(fn func(Connection, error)) ServerOption {
 	return func(c *serverConfig) { c.onDisconnect = fn }
+}
+
+// WithOnTransportDrop registers a callback invoked when a connection's
+// transport dies and the session enters the suspended state (resumeWindow > 0).
+// This does not fire when resumeWindow is 0. The callback runs in a separate goroutine.
+func WithOnTransportDrop(fn func(Connection, error)) ServerOption {
+	return func(c *serverConfig) { c.onTransportDrop = fn }
+}
+
+// WithOnTransportRestore registers a callback invoked when a suspended session
+// resumes after a client reconnects within the resume window. This does not
+// fire when resumeWindow is not configured. The callback runs in a separate goroutine.
+func WithOnTransportRestore(fn func(Connection)) ServerOption {
+	return func(c *serverConfig) { c.onTransportRestore = fn }
 }
 
 // WithHeartbeat configures Ping/Pong heartbeat intervals.

--- a/options.go
+++ b/options.go
@@ -96,7 +96,7 @@ func WithOnTransportDrop(fn func(Connection, error)) ServerOption {
 
 // WithOnTransportRestore registers a callback invoked when a suspended session
 // resumes after a client reconnects within the resume window. This does not
-// fire when resumeWindow is not configured. The callback runs in a separate goroutine.
+// fire when resumeWindow is 0. The callback runs in a separate goroutine.
 func WithOnTransportRestore(fn func(Connection)) ServerOption {
 	return func(c *serverConfig) { c.onTransportRestore = fn }
 }

--- a/resume_test.go
+++ b/resume_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestRingBuffer_PushAndDrain(t *testing.T) {
+	t.Parallel()
 	rb := newRingBuffer(4)
 
 	rb.Push([]byte("a"))
@@ -24,6 +25,7 @@ func TestRingBuffer_PushAndDrain(t *testing.T) {
 }
 
 func TestRingBuffer_DrainClearsBuffer(t *testing.T) {
+	t.Parallel()
 	rb := newRingBuffer(4)
 	rb.Push([]byte("x"))
 	rb.Drain()
@@ -35,6 +37,7 @@ func TestRingBuffer_DrainClearsBuffer(t *testing.T) {
 }
 
 func TestRingBuffer_Wraparound(t *testing.T) {
+	t.Parallel()
 	rb := newRingBuffer(3)
 
 	rb.Push([]byte("1"))
@@ -55,6 +58,7 @@ func TestRingBuffer_Wraparound(t *testing.T) {
 }
 
 func TestRingBuffer_Len(t *testing.T) {
+	t.Parallel()
 	rb := newRingBuffer(4)
 	if rb.Len() != 0 {
 		t.Fatalf("empty buffer Len: want 0, got %d", rb.Len())
@@ -67,6 +71,7 @@ func TestRingBuffer_Len(t *testing.T) {
 }
 
 func TestRingBuffer_SingleCapacity(t *testing.T) {
+	t.Parallel()
 	rb := newRingBuffer(1)
 	rb.Push([]byte("first"))
 	rb.Push([]byte("second"))
@@ -81,6 +86,7 @@ func TestRingBuffer_SingleCapacity(t *testing.T) {
 }
 
 func TestRingBuffer_ExactCapacity(t *testing.T) {
+	t.Parallel()
 	rb := newRingBuffer(3)
 	rb.Push([]byte("a"))
 	rb.Push([]byte("b"))
@@ -99,6 +105,7 @@ func TestRingBuffer_ExactCapacity(t *testing.T) {
 }
 
 func TestRingBuffer_LenAfterWraparound(t *testing.T) {
+	t.Parallel()
 	rb := newRingBuffer(2)
 	rb.Push([]byte("1"))
 	rb.Push([]byte("2"))

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -1690,13 +1690,22 @@ func TestServer_Resume_GraceExpiresAfterConnectionClose(t *testing.T) {
 	// Tests the handleGraceExpired stateClosed path: connection.Close()
 	// is called while suspended, then the grace timer fires.
 	connected := make(chan wspulse.Connection, 1)
+	dropped := make(chan struct{}, 1)
+	fc := newFakeClock()
 
 	srv := wspulse.NewServer(
 		acceptAll,
-		wspulse.WithResumeWindow(1*time.Second),
+		wspulse.WithResumeWindow(3*time.Minute),
+		wspulse.WithClock(fc),
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
 			select {
 			case connected <- connection:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
 			default:
 			}
 		}),
@@ -1713,14 +1722,19 @@ func TestServer_Resume_GraceExpiresAfterConnectionClose(t *testing.T) {
 
 	// Close transport → session suspends.
 	_ = c.Close()
-	time.Sleep(200 * time.Millisecond)
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
 
 	// Application calls Close() on the Connection while suspended.
 	_ = connection.Close()
 
-	// Wait for grace timer to fire (1 second). handleGraceExpired will see
-	// stateClosed and clean up maps without calling Close again.
-	time.Sleep(1500 * time.Millisecond)
+	// Fire the grace timer. handleGraceExpired will see stateClosed
+	// and clean up maps without calling Close again.
+	fc.Fire(0)
+	time.Sleep(50 * time.Millisecond)
 
 	// Verify session is fully cleaned up.
 	connections := srv.GetConnections("test-room")
@@ -1733,17 +1747,26 @@ func TestServer_Resume_GraceExpiresAfterConnectionClose(t *testing.T) {
 
 func TestServer_Resume_StaleGraceTimerIgnored(t *testing.T) {
 	// Connect, disconnect (suspend, timer start), reconnect (resume, epoch bump),
-	// disconnect again (new timer), let OLD timer fire (epoch mismatch → ignored),
+	// disconnect again (new timer), fire OLD timer (epoch mismatch → ignored),
 	// then reconnect again — session must still be alive.
 	connected := make(chan struct{}, 10)
 	disconnected := make(chan struct{}, 10)
+	dropped := make(chan struct{}, 10)
+	fc := newFakeClock()
 
 	srv := wspulse.NewServer(
 		acceptAll,
-		wspulse.WithResumeWindow(1*time.Second),
+		wspulse.WithResumeWindow(3*time.Minute),
+		wspulse.WithClock(fc),
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
 			select {
 			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
 			default:
 			}
 		}),
@@ -1756,7 +1779,7 @@ func TestServer_Resume_StaleGraceTimerIgnored(t *testing.T) {
 	)
 	t.Cleanup(srv.Close)
 
-	// Cycle 1: connect → disconnect (suspend).
+	// Cycle 1: connect → disconnect (suspend). Timer 0 (epoch=1).
 	c1, ts := dialTestServerRaw(t, srv)
 	select {
 	case <-connected:
@@ -1764,9 +1787,13 @@ func TestServer_Resume_StaleGraceTimerIgnored(t *testing.T) {
 		t.Fatal("timed out waiting for first connect")
 	}
 	_ = c1.Close()
-	time.Sleep(200 * time.Millisecond) // grace timer epoch=1 started
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first drop")
+	}
 
-	// Cycle 2: reconnect (resume, epoch bumped), disconnect again.
+	// Cycle 2: reconnect (resume, epoch bumped), disconnect again. Timer 1 (epoch=2).
 	u := "ws" + strings.TrimPrefix(ts.URL, "http")
 	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
 	c2, _, err := dialer.Dial(u, nil)
@@ -1775,7 +1802,11 @@ func TestServer_Resume_StaleGraceTimerIgnored(t *testing.T) {
 	}
 	time.Sleep(200 * time.Millisecond)
 	_ = c2.Close()
-	time.Sleep(200 * time.Millisecond) // grace timer epoch=2 started
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for second drop")
+	}
 
 	// Cycle 3: reconnect again (resume, epoch bumped again).
 	c3, _, err := dialer.Dial(u, nil)
@@ -1783,10 +1814,12 @@ func TestServer_Resume_StaleGraceTimerIgnored(t *testing.T) {
 		t.Fatalf("reconnect 2 failed: %v", err)
 	}
 	t.Cleanup(func() { _ = c3.Close() })
+	time.Sleep(200 * time.Millisecond)
 
-	// Wait for the old timers (epoch=1, epoch=2) to fire — both should be
-	// detected as stale and ignored.
-	time.Sleep(1200 * time.Millisecond)
+	// Fire old timers (epoch=1, epoch=2) — both should be detected as stale.
+	fc.Fire(0)
+	fc.Fire(1)
+	time.Sleep(50 * time.Millisecond)
 
 	// Session should still be alive.
 	select {
@@ -3226,10 +3259,12 @@ func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
 
 func TestOnTransportDrop_GraceExpires_ThenDisconnect(t *testing.T) {
 	events := make(chan string, 4)
+	fc := newFakeClock()
 
 	srv := wspulse.NewServer(
 		acceptAll,
-		wspulse.WithResumeWindow(500*time.Millisecond),
+		wspulse.WithResumeWindow(3*time.Minute),
+		wspulse.WithClock(fc),
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
 			events <- "connect"
 		}),
@@ -3263,6 +3298,8 @@ func TestOnTransportDrop_GraceExpires_ThenDisconnect(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for drop event")
 	}
+
+	fc.Fire(0)
 
 	select {
 	case e := <-events:

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -3070,8 +3070,8 @@ func TestOnTransportRestore_FiresOnResume(t *testing.T) {
 func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
-	var dropFired atomic.Bool
-	var restoreFired atomic.Bool
+	dropFired := make(chan struct{}, 1)
+	restoreFired := make(chan struct{}, 1)
 
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -3089,10 +3089,16 @@ func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
 			}
 		}),
 		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
-			dropFired.Store(true)
+			select {
+			case dropFired <- struct{}{}:
+			default:
+			}
 		}),
 		wspulse.WithOnTransportRestore(func(connection wspulse.Connection) {
-			restoreFired.Store(true)
+			select {
+			case restoreFired <- struct{}{}:
+			default:
+			}
 		}),
 	)
 	t.Cleanup(srv.Close)
@@ -3112,14 +3118,19 @@ func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
 		t.Fatal("timed out waiting for OnDisconnect")
 	}
 
-	// Give callbacks a moment to fire (they should not).
-	time.Sleep(200 * time.Millisecond)
-
-	if dropFired.Load() {
+	// Verify transport callbacks did not fire (no resume window configured).
+	select {
+	case <-dropFired:
 		t.Error("OnTransportDrop fired without resume window")
+	case <-time.After(200 * time.Millisecond):
+		// OK — callback did not fire.
 	}
-	if restoreFired.Load() {
+
+	select {
+	case <-restoreFired:
 		t.Error("OnTransportRestore fired without resume window")
+	case <-time.After(200 * time.Millisecond):
+		// OK — callback did not fire.
 	}
 }
 
@@ -3322,5 +3333,76 @@ func TestOnTransportRestore_FiresAfterStateConnected(t *testing.T) {
 	}
 	if f.Event != "from-restore" {
 		t.Errorf("event: want %q, got %q", "from-restore", f.Event)
+	}
+}
+
+func TestOnTransportRestore_NotFiredOnClosedSession(t *testing.T) {
+	connected := make(chan wspulse.Connection, 2)
+	dropped := make(chan struct{}, 1)
+	restoreFired := make(chan struct{}, 1)
+
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithResumeWindow(5*time.Second),
+		wspulse.WithOnConnect(func(connection wspulse.Connection) {
+			select {
+			case connected <- connection:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			// Close the session from the drop callback. This sets
+			// state = stateClosed while the session is still suspended.
+			// If the reconnect arrives before the hub processes the
+			// graceExpired message, handleRegister sees stateSuspended
+			// and calls attachWS — the transition goroutine must check
+			// state before firing onResumeComplete.
+			_ = connection.Close()
+			select {
+			case dropped <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportRestore(func(connection wspulse.Connection) {
+			select {
+			case restoreFired <- struct{}{}:
+			default:
+			}
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	c1, ts := dialTestServerRaw(t, srv)
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first connect")
+	}
+
+	// Drop transport → session suspends, OnTransportDrop fires and calls Close().
+	_ = c1.Close()
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	// Reconnect with the same connectionID immediately. Depending on
+	// hub event ordering, the old closed session may or may not still
+	// be registered. Either way, OnTransportRestore must NOT fire for
+	// a session that was closed.
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	c2, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("reconnect dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Close() })
+
+	select {
+	case <-restoreFired:
+		t.Fatal("OnTransportRestore fired on a closed session")
+	case <-time.After(200 * time.Millisecond):
+		// OK — callback did not fire for the closed session.
 	}
 }

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -2958,3 +2958,295 @@ func TestServer_Resume_CloseRacesTransportDied(t *testing.T) {
 		t.Fatalf("want %d onDisconnect within 3s, got %d (delayed by grace window?)", count, got)
 	}
 }
+
+// ── Transport callback tests ──────────────────────────────────────────────────
+
+func TestOnTransportDrop_FiresOnSuspend(t *testing.T) {
+	connected := make(chan struct{}, 1)
+	dropped := make(chan wspulse.Connection, 1)
+	droppedErr := make(chan error, 1)
+
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithResumeWindow(5*time.Second),
+		wspulse.WithOnConnect(func(connection wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			dropped <- connection
+			droppedErr <- err
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	c := dialTestServer(t, srv)
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for connect")
+	}
+
+	_ = c.Close()
+
+	select {
+	case conn := <-dropped:
+		if conn.ID() != "test-connection" {
+			t.Errorf("connection ID: want %q, got %q", "test-connection", conn.ID())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	// err may be nil for a normal closure (CloseNormalClosure).
+	select {
+	case <-droppedErr:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop error")
+	}
+}
+
+func TestOnTransportRestore_FiresOnResume(t *testing.T) {
+	connected := make(chan struct{}, 2)
+	dropped := make(chan struct{}, 1)
+	restored := make(chan wspulse.Connection, 1)
+
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithResumeWindow(5*time.Second),
+		wspulse.WithOnConnect(func(connection wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportRestore(func(connection wspulse.Connection) {
+			restored <- connection
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	c1, ts := dialTestServerRaw(t, srv)
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first connect")
+	}
+
+	_ = c1.Close()
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	// Reconnect with same connectionID.
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	c2, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("reconnect dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Close() })
+
+	select {
+	case conn := <-restored:
+		if conn.ID() != "test-connection" {
+			t.Errorf("connection ID: want %q, got %q", "test-connection", conn.ID())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportRestore")
+	}
+}
+
+func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
+	connected := make(chan struct{}, 1)
+	disconnected := make(chan struct{}, 1)
+	var dropFired atomic.Bool
+	var restoreFired atomic.Bool
+
+	srv := wspulse.NewServer(
+		acceptAll,
+		// No WithResumeWindow — default is 0.
+		wspulse.WithOnConnect(func(connection wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnDisconnect(func(connection wspulse.Connection, err error) {
+			select {
+			case disconnected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			dropFired.Store(true)
+		}),
+		wspulse.WithOnTransportRestore(func(connection wspulse.Connection) {
+			restoreFired.Store(true)
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	c := dialTestServer(t, srv)
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for connect")
+	}
+
+	_ = c.Close()
+
+	select {
+	case <-disconnected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnDisconnect")
+	}
+
+	// Give callbacks a moment to fire (they should not).
+	time.Sleep(200 * time.Millisecond)
+
+	if dropFired.Load() {
+		t.Error("OnTransportDrop fired without resume window")
+	}
+	if restoreFired.Load() {
+		t.Error("OnTransportRestore fired without resume window")
+	}
+}
+
+func TestOnTransportDrop_GraceExpires_ThenDisconnect(t *testing.T) {
+	events := make(chan string, 4)
+
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithResumeWindow(500*time.Millisecond),
+		wspulse.WithOnConnect(func(connection wspulse.Connection) {
+			events <- "connect"
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			events <- "drop"
+		}),
+		wspulse.WithOnDisconnect(func(connection wspulse.Connection, err error) {
+			events <- "disconnect"
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	c := dialTestServer(t, srv)
+	select {
+	case e := <-events:
+		if e != "connect" {
+			t.Fatalf("first event: want %q, got %q", "connect", e)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for connect event")
+	}
+
+	_ = c.Close()
+
+	// Expect: drop fires first, then disconnect fires after grace expires.
+	select {
+	case e := <-events:
+		if e != "drop" {
+			t.Fatalf("second event: want %q, got %q", "drop", e)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for drop event")
+	}
+
+	select {
+	case e := <-events:
+		if e != "disconnect" {
+			t.Fatalf("third event: want %q, got %q", "disconnect", e)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for disconnect event")
+	}
+}
+
+func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
+	events := make(chan string, 4)
+	connected := make(chan struct{}, 2)
+	dropped := make(chan struct{}, 1)
+
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithResumeWindow(5*time.Second),
+		wspulse.WithOnConnect(func(connection wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportRestore(func(connection wspulse.Connection) {
+			events <- "restore"
+		}),
+		wspulse.WithOnMessage(func(connection wspulse.Connection, f wspulse.Frame) {
+			events <- "message"
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	c1, ts := dialTestServerRaw(t, srv)
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first connect")
+	}
+
+	_ = c1.Close()
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	// Reconnect.
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	c2, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("reconnect dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Close() })
+
+	// Wait for restore event first.
+	select {
+	case e := <-events:
+		if e != "restore" {
+			t.Fatalf("first event after reconnect: want %q, got %q", "restore", e)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for restore event")
+	}
+
+	// Now send a message on the new transport.
+	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "ping"})
+	if err := c2.WriteMessage(websocket.TextMessage, encoded); err != nil {
+		t.Fatalf("WriteMessage failed: %v", err)
+	}
+
+	select {
+	case e := <-events:
+		if e != "message" {
+			t.Fatalf("second event after reconnect: want %q, got %q", "message", e)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message event")
+	}
+}

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -106,6 +106,7 @@ func (failingCodec) Decode(data []byte) (wspulse.Frame, error) {
 func (failingCodec) FrameType() int { return wspulse.TextMessage }
 
 func TestServer_ConnectFunc_RejectReturns401(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(func(r *http.Request) (string, string, error) {
 		return "", "", errors.New("unauthorized")
 	})
@@ -123,6 +124,7 @@ func TestServer_ConnectFunc_RejectReturns401(t *testing.T) {
 }
 
 func TestServer_OnConnect_SendsFrame(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(
 		acceptAll,
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
@@ -146,6 +148,7 @@ func TestServer_OnConnect_SendsFrame(t *testing.T) {
 }
 
 func TestServer_OnMessage_CallbackFires(t *testing.T) {
+	t.Parallel()
 	received := make(chan wspulse.Frame, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -171,6 +174,7 @@ func TestServer_OnMessage_CallbackFires(t *testing.T) {
 }
 
 func TestServer_Broadcast_ReachesConnectedClient(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -207,6 +211,7 @@ func TestServer_Broadcast_ReachesConnectedClient(t *testing.T) {
 }
 
 func TestServer_OnDisconnect_CallbackFires(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{})
 	var once sync.Once
 	srv := wspulse.NewServer(
@@ -235,6 +240,7 @@ func TestServer_OnDisconnect_CallbackFires(t *testing.T) {
 }
 
 func TestServer_Send_DeliversFrameToConnection(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -271,6 +277,7 @@ func TestServer_Send_DeliversFrameToConnection(t *testing.T) {
 }
 
 func TestServer_Kick_ClosesConnection(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{})
 	var once sync.Once
@@ -304,6 +311,7 @@ func TestServer_Kick_ClosesConnection(t *testing.T) {
 }
 
 func TestServer_GetConnections_ReturnsRegisteredConnection(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -334,6 +342,7 @@ func TestServer_GetConnections_ReturnsRegisteredConnection(t *testing.T) {
 }
 
 func TestServer_DuplicateConnectionID_OldKickedNewReachable(t *testing.T) {
+	t.Parallel()
 	var (
 		firstConnected  = make(chan struct{})
 		secondConnected = make(chan struct{})
@@ -418,6 +427,7 @@ func TestServer_DuplicateConnectionID_OldKickedNewReachable(t *testing.T) {
 // ── Race & backpressure tests ─────────────────────────────────────────────────
 
 func TestServer_ConcurrentBroadcast_NoRace(t *testing.T) {
+	t.Parallel()
 	const workers = 8
 	const messagesPerWorker = 50
 
@@ -473,6 +483,7 @@ func TestServer_ConcurrentBroadcast_NoRace(t *testing.T) {
 }
 
 func TestServer_CloseWhileConnecting_NoLeak(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(
 		func(r *http.Request) (string, string, error) {
 			return "room", "", nil
@@ -507,6 +518,7 @@ func TestServer_CloseWhileConnecting_NoLeak(t *testing.T) {
 }
 
 func TestServer_BroadcastDropsOldest_SlowClient(t *testing.T) {
+	t.Parallel()
 	const bufferSize = 2
 	const totalBroadcasts = 200
 
@@ -571,6 +583,7 @@ func TestServer_BroadcastDropsOldest_SlowClient(t *testing.T) {
 }
 
 func TestServer_ShutdownFiresOnDisconnect(t *testing.T) {
+	t.Parallel()
 	const connectionCount = 3
 	var mu sync.Mutex
 	disconnected := make(map[string]error)
@@ -631,6 +644,7 @@ func TestServer_ShutdownFiresOnDisconnect(t *testing.T) {
 }
 
 func TestServer_ReadPumpPanicRecovery(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -658,6 +672,7 @@ func TestServer_ReadPumpPanicRecovery(t *testing.T) {
 }
 
 func TestServer_ConnectionSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -698,6 +713,7 @@ func TestServer_ConnectionSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T)
 }
 
 func TestServer_ConnectionDone_ClosedOnKick(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -726,6 +742,7 @@ func TestServer_ConnectionDone_ClosedOnKick(t *testing.T) {
 }
 
 func TestServer_MultipleRooms_BroadcastIsolation(t *testing.T) {
+	t.Parallel()
 	connectionIndex := 0
 	var mu sync.Mutex
 	srv := wspulse.NewServer(
@@ -778,6 +795,7 @@ func TestServer_MultipleRooms_BroadcastIsolation(t *testing.T) {
 }
 
 func TestServer_GetConnections_EmptyAfterDisconnect(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -809,6 +827,7 @@ func TestServer_GetConnections_EmptyAfterDisconnect(t *testing.T) {
 }
 
 func TestServer_Resume_ReconnectWithinWindow(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	connected := make(chan struct{}, 2)
 
@@ -878,6 +897,7 @@ func TestServer_Resume_ReconnectWithinWindow(t *testing.T) {
 }
 
 func TestServer_Resume_GraceExpires_FiresOnDisconnect(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	connected := make(chan struct{}, 1)
 	dropped := make(chan struct{}, 1)
@@ -933,6 +953,7 @@ func TestServer_Resume_GraceExpires_FiresOnDisconnect(t *testing.T) {
 }
 
 func TestServer_Resume_BufferedFramesDelivered(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 2)
 
 	srv := wspulse.NewServer(
@@ -994,6 +1015,7 @@ func TestServer_Resume_BufferedFramesDelivered(t *testing.T) {
 }
 
 func TestServer_Resume_KickBypassesWindow(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	connected := make(chan struct{}, 1)
 
@@ -1034,6 +1056,7 @@ func TestServer_Resume_KickBypassesWindow(t *testing.T) {
 }
 
 func TestServer_Resume_NoResumeWindow_DisconnectsImmediately(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	connected := make(chan struct{}, 1)
 
@@ -1072,6 +1095,7 @@ func TestServer_Resume_NoResumeWindow_DisconnectsImmediately(t *testing.T) {
 }
 
 func TestServer_Resume_ServerCloseTerminatesSuspended(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	connected := make(chan struct{}, 1)
 
@@ -1112,6 +1136,7 @@ func TestServer_Resume_ServerCloseTerminatesSuspended(t *testing.T) {
 }
 
 func TestServer_Resume_BroadcastWhileSuspended(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 2)
 
 	srv := wspulse.NewServer(
@@ -1160,6 +1185,7 @@ func TestServer_Resume_BroadcastWhileSuspended(t *testing.T) {
 // ── Race condition tests for resume ───────────────────────────────────────────
 
 func TestServer_Resume_ConcurrentReconnect_NoRace(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(
 		acceptAll,
 		wspulse.WithResumeWindow(2*time.Second),
@@ -1183,6 +1209,7 @@ func TestServer_Resume_ConcurrentReconnect_NoRace(t *testing.T) {
 }
 
 func TestServer_Resume_ConcurrentBroadcastDuringResume_NoRace(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(
 		acceptAll,
 		wspulse.WithResumeWindow(2*time.Second),
@@ -1225,6 +1252,7 @@ func TestServer_Resume_ConcurrentBroadcastDuringResume_NoRace(t *testing.T) {
 }
 
 func TestWithCheckOrigin_RejectsConnection(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithCheckOrigin(func(r *http.Request) bool { return false }),
 	)
@@ -1242,6 +1270,7 @@ func TestWithCheckOrigin_RejectsConnection(t *testing.T) {
 // ── ServeHTTP edge case tests ─────────────────────────────────────────────────
 
 func TestServer_ServeHTTP_AfterClose_Returns503(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	srv.Close()
 
@@ -1259,6 +1288,7 @@ func TestServer_ServeHTTP_AfterClose_Returns503(t *testing.T) {
 }
 
 func TestServer_ServeHTTP_EmptyConnectionID_GetsUUID(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	srv := wspulse.NewServer(
 		func(r *http.Request) (string, string, error) {
@@ -1284,6 +1314,7 @@ func TestServer_ServeHTTP_EmptyConnectionID_GetsUUID(t *testing.T) {
 // ── Session Send edge case tests ──────────────────────────────────────────────
 
 func TestServer_ConnectionSend_AfterClose_ReturnsErrConnectionClosed(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -1313,6 +1344,7 @@ func TestServer_ConnectionSend_AfterClose_ReturnsErrConnectionClosed(t *testing.
 // ── Broadcast edge case tests ─────────────────────────────────────────────────
 
 func TestServer_Broadcast_SkipsClosedSession(t *testing.T) {
+	t.Parallel()
 	// Broadcast while a connection is being kicked should not panic.
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
@@ -1340,6 +1372,7 @@ func TestServer_Broadcast_SkipsClosedSession(t *testing.T) {
 // ── readPump edge case tests ──────────────────────────────────────────────────
 
 func TestServer_ReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
+	t.Parallel()
 	received := make(chan wspulse.Frame, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -1374,6 +1407,7 @@ func TestServer_ReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
 // ── Resume: stale closed session in register ─────────────────────────────────
 
 func TestServer_Resume_StaleClosedSession_Reconnect(t *testing.T) {
+	t.Parallel()
 	// Trigger the stateClosed path in handleRegister: connect, let grace
 	// expire (session becomes closed), then reconnect with the same ID.
 	connected := make(chan struct{}, 4)
@@ -1462,6 +1496,7 @@ func TestServer_Resume_StaleClosedSession_Reconnect(t *testing.T) {
 // ── Server.Close() synchronous behavior ───────────────────────────────────────
 
 func TestServer_Close_BlocksUntilHubExits(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -1497,6 +1532,7 @@ func TestServer_Close_BlocksUntilHubExits(t *testing.T) {
 // ── Concurrent Close and Kick ─────────────────────────────────────────────────
 
 func TestServer_ConcurrentCloseAndKick_NoRace(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -1530,6 +1566,7 @@ func TestServer_ConcurrentCloseAndKick_NoRace(t *testing.T) {
 // ── Concurrent Close and Broadcast ────────────────────────────────────────────
 
 func TestServer_ConcurrentCloseAndBroadcast_NoRace(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -1565,6 +1602,7 @@ func TestServer_ConcurrentCloseAndBroadcast_NoRace(t *testing.T) {
 // ── Resume: connection.Close() while suspended ───────────────────────────────
 
 func TestServer_Resume_ConnectionCloseWhileSuspended(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	disconnected := make(chan struct{}, 1)
 
@@ -1612,6 +1650,7 @@ func TestServer_Resume_ConnectionCloseWhileSuspended(t *testing.T) {
 // ── Multiple rapid resume cycles ──────────────────────────────────────────────
 
 func TestServer_Resume_MultipleRapidCycles(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(
 		acceptAll,
 		wspulse.WithResumeWindow(5*time.Second),
@@ -1634,6 +1673,7 @@ func TestServer_Resume_MultipleRapidCycles(t *testing.T) {
 }
 
 func TestServer_Broadcast_EncodeError_ReturnsError(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -1660,6 +1700,7 @@ func TestServer_Broadcast_EncodeError_ReturnsError(t *testing.T) {
 }
 
 func TestServer_ConnectionSend_EncodeError_ReturnsError(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -1687,6 +1728,7 @@ func TestServer_ConnectionSend_EncodeError_ReturnsError(t *testing.T) {
 // ── Grace expired for already-closed session ─────────────────────────────────
 
 func TestServer_Resume_GraceExpiresAfterConnectionClose(t *testing.T) {
+	t.Parallel()
 	// Tests the handleGraceExpired stateClosed path: connection.Close()
 	// is called while suspended, then the grace timer fires.
 	connected := make(chan wspulse.Connection, 1)
@@ -1746,6 +1788,7 @@ func TestServer_Resume_GraceExpiresAfterConnectionClose(t *testing.T) {
 // ── Resume: stale grace timer (epoch mismatch) ──────────────────────────────
 
 func TestServer_Resume_StaleGraceTimerIgnored(t *testing.T) {
+	t.Parallel()
 	// Connect, disconnect (suspend, timer start), reconnect (resume, epoch bump),
 	// disconnect again (new timer), fire OLD timer (epoch mismatch → ignored),
 	// then reconnect again — session must still be alive.
@@ -1836,6 +1879,7 @@ func TestServer_Resume_StaleGraceTimerIgnored(t *testing.T) {
 // ── handleTransportDied: transport-died for closed session (kick then readPump reports) ─
 
 func TestServer_Resume_KickWhileConnected_TransportDiedHandled(t *testing.T) {
+	t.Parallel()
 	// When Kick is called on a connected session with resume enabled,
 	// the session transitions to stateClosed. Later when readPump exits
 	// (transport closed by writePump's defer), the transportDiedMessage
@@ -1883,6 +1927,7 @@ func TestServer_Resume_KickWhileConnected_TransportDiedHandled(t *testing.T) {
 // ── readPump and writePump: inline hub-shutdown cleanup ──────────────────────
 
 func TestServer_HubShutdown_ReadPumpInlineCleanup(t *testing.T) {
+	t.Parallel()
 	// When the hub is closed while connections are active, readPumps that
 	// discover h.done is closed should call s.closeOnce.Do inline.
 	const count = 5
@@ -1941,6 +1986,7 @@ func TestServer_HubShutdown_ReadPumpInlineCleanup(t *testing.T) {
 // ── Duplicate connection with resume enabled ─────────────────────────────────
 
 func TestServer_Resume_DuplicateID_WhileConnected_KicksOld(t *testing.T) {
+	t.Parallel()
 	var (
 		firstConnected  = make(chan struct{})
 		kicked          = make(chan struct{})
@@ -1986,6 +2032,7 @@ func TestServer_Resume_DuplicateID_WhileConnected_KicksOld(t *testing.T) {
 // ── Pong handler coverage ────────────────────────────────────────────────────
 
 func TestServer_PongHandler_ResetsReadDeadline(t *testing.T) {
+	t.Parallel()
 	// Use a short ping period so the server sends a Ping quickly.
 	// The gorilla client auto-responds with Pong, which fires the
 	// PongHandler on the server and covers that code path.
@@ -2021,6 +2068,7 @@ func TestServer_PongHandler_ResetsReadDeadline(t *testing.T) {
 // ── Normal close frame (covers "connection closed normally" log) ─────────────
 
 func TestServer_NormalCloseFrame_LogsNormally(t *testing.T) {
+	t.Parallel()
 	disconnected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		acceptAll,
@@ -2059,6 +2107,7 @@ func TestServer_NormalCloseFrame_LogsNormally(t *testing.T) {
 // ── writePump pumpQuit: verify pump stops on transport swap ──────────────────
 
 func TestServer_Resume_WritePumpStopsOnPumpQuit(t *testing.T) {
+	t.Parallel()
 	// Verifies that writePump exits via pumpQuit when the session is suspended.
 	// After suspend + resume, the old writePump must have exited (via pumpQuit),
 	// because the new writePump successfully delivers frames.
@@ -2122,6 +2171,7 @@ func TestServer_Resume_WritePumpStopsOnPumpQuit(t *testing.T) {
 // ── No OnMessage callback: readPump should still process frames ──────────────
 
 func TestServer_NoOnMessage_ReadPumpStillProcesses(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll) // no OnMessage callback
 	t.Cleanup(srv.Close)
 	c := dialTestServer(t, srv)
@@ -2137,6 +2187,7 @@ func TestServer_NoOnMessage_ReadPumpStillProcesses(t *testing.T) {
 // ── handleRegister stateClosed path (app-closed then reconnect) ──────────────
 
 func TestServer_Resume_ConnectionCloseWhileSuspended_ThenReconnect(t *testing.T) {
+	t.Parallel()
 	// Hits the stateClosed path in handleRegister: session is closed by
 	// the application while suspended, then a reconnect arrives before
 	// the grace timer fires.
@@ -2208,6 +2259,7 @@ func TestServer_Resume_ConnectionCloseWhileSuspended_ThenReconnect(t *testing.T)
 // ── Resume: stateClosed path in handleRegister fires onDisconnect ─────────────
 
 func TestServer_Resume_StaleClosedSession_OnDisconnectFires(t *testing.T) {
+	t.Parallel()
 	// Regression test: handleRegister's stateClosed branch must fire onDisconnect.
 	// When Close() is called on a suspended session and a new connection with
 	// the same ID arrives before the hub processes the resulting
@@ -2298,6 +2350,7 @@ func TestServer_Resume_StaleClosedSession_OnDisconnectFires(t *testing.T) {
 // ── Broadcast covers done-check skip path ────────────────────────────────────
 
 func TestServer_Broadcast_SkipsDirectlyClosedSession(t *testing.T) {
+	t.Parallel()
 	// When an application calls connection.Close() directly (not via Kick),
 	// the session remains in the hub maps but has done closed. A subsequent
 	// broadcast should silently skip this session via the <-target.done check.
@@ -2331,6 +2384,7 @@ func TestServer_Broadcast_SkipsDirectlyClosedSession(t *testing.T) {
 // ── writePump: detach with long ping to ensure pumpQuit fires first ──────────
 
 func TestServer_Resume_WritePumpExitsViaPumpQuit(t *testing.T) {
+	t.Parallel()
 	// With a long ping period, writePump is guaranteed to be idle in the
 	// main select when pumpQuit fires (no tick to cause a write error first).
 	connected := make(chan struct{}, 2)
@@ -2384,6 +2438,7 @@ func TestServer_Resume_WritePumpExitsViaPumpQuit(t *testing.T) {
 // ── Session.Send when done closes concurrently ──────────────────────────────
 
 func TestServer_ConnectionSend_DoneClosesDuringEnqueue(t *testing.T) {
+	t.Parallel()
 	// Exercises the <-s.done path inside enqueue's three-way select
 	// by racing Send calls against Close.
 	connected := make(chan wspulse.Connection, 1)
@@ -2429,6 +2484,7 @@ func TestServer_ConnectionSend_DoneClosesDuringEnqueue(t *testing.T) {
 // the else branch of IsUnexpectedCloseError (the "connection closed normally"
 // debug log), because CloseGoingAway is in the expected close code list.
 func TestServer_ReadPump_NormalCloseFrame(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
 
@@ -2492,6 +2548,7 @@ func TestServer_ReadPump_NormalCloseFrame(t *testing.T) {
 // (set by Connection.Close()) when the transport-died event arrives.
 // The hub should still clean up maps and fire onDisconnect.
 func TestServer_ConnectionClose_StateClosed_TransportDied(t *testing.T) {
+	t.Parallel()
 	var capturedConn wspulse.Connection
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
@@ -2533,6 +2590,7 @@ func TestServer_ConnectionClose_StateClosed_TransportDied(t *testing.T) {
 // successfully resumed (stateConnected) by the time the grace timer
 // fires. The hub should skip destruction and the session stays alive.
 func TestServer_Resume_GraceTimerFiresAfterReconnect(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
 	dropped := make(chan struct{}, 1)
@@ -2621,6 +2679,7 @@ func TestServer_Resume_GraceTimerFiresAfterReconnect(t *testing.T) {
 // This happens when a session is suspended, resumed, and suspended again —
 // the first timer fires with the old epoch and should be ignored.
 func TestServer_Resume_StaleGraceTimer(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
 
@@ -2682,6 +2741,7 @@ func TestServer_Resume_StaleGraceTimer(t *testing.T) {
 // is in stateClosed before the transport dies. The hub enters the stateClosed
 // case of the non-connected switch and cleans up.
 func TestServer_ConnectionClose_StateClosed_Resume(t *testing.T) {
+	t.Parallel()
 	var capturedConn wspulse.Connection
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
@@ -2723,6 +2783,7 @@ func TestServer_ConnectionClose_StateClosed_Resume(t *testing.T) {
 // multiple buffered frames, the drain loop must apply drop-oldest backpressure
 // to enqueue resume frames.
 func TestServer_Resume_DrainBufferFull(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
 
@@ -2800,6 +2861,7 @@ func TestServer_Resume_DrainBufferFull(t *testing.T) {
 // onDisconnect once the grace timer expires. This covers the stateClosed
 // path in handleGraceExpired.
 func TestServer_Resume_ConnectionCloseWhileSuspended_FiresOnDisconnect(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	disconnected := make(chan struct{})
 	var once sync.Once
@@ -2863,6 +2925,7 @@ func TestServer_Resume_ConnectionCloseWhileSuspended_FiresOnDisconnect(t *testin
 // Regression: previously onDisconnect was delayed until the grace timer
 // fired naturally, even if the application had already called Close().
 func TestServer_Resume_ConnectionClose_ImmediateOnDisconnect(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)
 	disconnected := make(chan struct{})
 	var once sync.Once
@@ -2928,6 +2991,7 @@ func TestServer_Resume_ConnectionClose_ImmediateOnDisconnect(t *testing.T) {
 // onDisconnect callbacks were never invoked due to the internal close
 // coordination logic dropping events.
 func TestServer_Resume_MassCloseWhileSuspended_AllOnDisconnect(t *testing.T) {
+	t.Parallel()
 	const count = 200
 
 	var mu sync.Mutex
@@ -3020,6 +3084,7 @@ func TestServer_Resume_MassCloseWhileSuspended_AllOnDisconnect(t *testing.T) {
 // To maximise the chance of hitting this window, the test closes the
 // transport and immediately calls Close() without waiting for suspension.
 func TestServer_Resume_CloseRacesTransportDied(t *testing.T) {
+	t.Parallel()
 	const count = 50
 
 	connected := make(chan wspulse.Connection, count)
@@ -3085,6 +3150,7 @@ func TestServer_Resume_CloseRacesTransportDied(t *testing.T) {
 // ── Transport callback tests ──────────────────────────────────────────────────
 
 func TestOnTransportDrop_FiresOnSuspend(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	dropped := make(chan wspulse.Connection, 1)
 	droppedErr := make(chan error, 1)
@@ -3132,6 +3198,7 @@ func TestOnTransportDrop_FiresOnSuspend(t *testing.T) {
 }
 
 func TestOnTransportRestore_FiresOnResume(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 2)
 	dropped := make(chan struct{}, 1)
 	restored := make(chan wspulse.Connection, 1)
@@ -3191,6 +3258,7 @@ func TestOnTransportRestore_FiresOnResume(t *testing.T) {
 }
 
 func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
 	dropFired := make(chan struct{}, 1)
@@ -3258,6 +3326,7 @@ func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
 }
 
 func TestOnTransportDrop_GraceExpires_ThenDisconnect(t *testing.T) {
+	t.Parallel()
 	events := make(chan string, 4)
 	fc := newFakeClock()
 
@@ -3312,6 +3381,7 @@ func TestOnTransportDrop_GraceExpires_ThenDisconnect(t *testing.T) {
 }
 
 func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
+	t.Parallel()
 	events := make(chan string, 4)
 	connected := make(chan struct{}, 2)
 	dropped := make(chan struct{}, 1)
@@ -3395,6 +3465,7 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 // to the resume buffer (which has already been drained), and the frame will never
 // reach the client.
 func TestOnTransportRestore_FiresAfterStateConnected(t *testing.T) {
+	t.Parallel()
 	connected := make(chan struct{}, 2)
 	dropped := make(chan struct{}, 1)
 
@@ -3464,6 +3535,7 @@ func TestOnTransportRestore_FiresAfterStateConnected(t *testing.T) {
 }
 
 func TestOnTransportRestore_NotFiredOnClosedSession(t *testing.T) {
+	t.Parallel()
 	connected := make(chan wspulse.Connection, 2)
 	dropped := make(chan struct{}, 1)
 	restoreFired := make(chan struct{}, 1)

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -47,17 +47,27 @@ func dialTestServerRaw(t *testing.T, srv wspulse.Server) (*websocket.Conn, *http
 	return c, ts
 }
 
-// ── Fake clock for grace-timer tests ─────────────────────────────────────────
+// ── Fake clock ───────────────────────────────────────────────────────────────
+//
+// fakeClock replaces both AfterFunc (grace timer) and NewTicker (heartbeat)
+// with controllable fakes. No real timers fire — tests drive time explicitly
+// via Fire (for AfterFunc callbacks) or by reading the returned ticker fields.
 
 type fakeClock struct {
-	mu     sync.Mutex
-	timers []*fakeTimer
+	mu      sync.Mutex
+	timers  []*fakeTimer
+	tickers []*fakeTicker
 }
 
 type fakeTimer struct {
 	d     time.Duration
 	fn    func()
 	timer *time.Timer
+}
+
+type fakeTicker struct {
+	d      time.Duration
+	ticker *time.Ticker
 }
 
 func newFakeClock() *fakeClock { return &fakeClock{} }
@@ -76,8 +86,16 @@ func (fc *fakeClock) AfterFunc(d time.Duration, f func()) *time.Timer {
 	return t
 }
 
+// NewTicker returns a stopped ticker that will never fire on its own.
+// This prevents heartbeat pings from interfering with tests that use
+// fakeClock. The ticker is recorded for inspection if needed.
 func (fc *fakeClock) NewTicker(d time.Duration) *time.Ticker {
-	return time.NewTicker(d)
+	t := time.NewTicker(time.Hour)
+	t.Stop()
+	fc.mu.Lock()
+	fc.tickers = append(fc.tickers, &fakeTicker{d: d, ticker: t})
+	fc.mu.Unlock()
+	return t
 }
 
 // Fire executes the callback of the i-th registered AfterFunc (0-based).
@@ -86,6 +104,20 @@ func (fc *fakeClock) Fire(i int) {
 	ft := fc.timers[i]
 	fc.mu.Unlock()
 	ft.fn()
+}
+
+// TimerCount returns the number of registered AfterFunc timers.
+func (fc *fakeClock) TimerCount() int {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return len(fc.timers)
+}
+
+// TickerCount returns the number of registered tickers.
+func (fc *fakeClock) TickerCount() int {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return len(fc.tickers)
 }
 
 // Len returns the number of registered timers.

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -62,6 +62,11 @@ type fakeTimer struct {
 
 func newFakeClock() *fakeClock { return &fakeClock{} }
 
+// AfterFunc returns a stopped *time.Timer created via time.AfterFunc.
+// The timer will not fire on its own — tests must call fc.Fire(i) to
+// invoke the callback. Because time.AfterFunc is used (not time.NewTimer),
+// Reset(0) correctly re-invokes the callback, matching production semantics
+// (e.g. session.Close() calls graceTimer.Reset(0) to force immediate expiry).
 func (fc *fakeClock) AfterFunc(d time.Duration, f func()) *time.Timer {
 	t := time.AfterFunc(time.Hour, f)
 	t.Stop()

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -3250,3 +3250,77 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 		t.Fatal("timed out waiting for message event")
 	}
 }
+
+// TestOnTransportRestore_FiresAfterStateConnected verifies that OnTransportRestore
+// fires only after the session has transitioned to stateConnected (pumps running).
+// If the callback fires while the session is still suspended, Send() will buffer
+// to the resume buffer (which has already been drained), and the frame will never
+// reach the client.
+func TestOnTransportRestore_FiresAfterStateConnected(t *testing.T) {
+	connected := make(chan struct{}, 2)
+	dropped := make(chan struct{}, 1)
+
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithResumeWindow(5*time.Second),
+		wspulse.WithOnConnect(func(connection wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportRestore(func(connection wspulse.Connection) {
+			// Send a frame from within the callback. If this fires
+			// before stateConnected, the frame goes to the resume
+			// buffer (already drained) and never reaches the client.
+			_ = connection.Send(wspulse.Frame{
+				Event:   "from-restore",
+				Payload: []byte(`"hello"`),
+			})
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	c1, ts := dialTestServerRaw(t, srv)
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first connect")
+	}
+
+	_ = c1.Close()
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	// Reconnect with same connectionID.
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	c2, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("reconnect dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Close() })
+
+	// The client must receive the frame sent from OnTransportRestore.
+	_ = c2.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, message, err := c2.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage failed (frame from OnTransportRestore not received): %v", err)
+	}
+	f, err := wspulse.JSONCodec.Decode(message)
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if f.Event != "from-restore" {
+		t.Errorf("event: want %q, got %q", "from-restore", f.Event)
+	}
+}

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -4,6 +4,7 @@ package wspulse_test
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -101,6 +102,10 @@ func (fc *fakeClock) NewTicker(d time.Duration) *time.Ticker {
 // Fire executes the callback of the i-th registered AfterFunc (0-based).
 func (fc *fakeClock) Fire(i int) {
 	fc.mu.Lock()
+	if i >= len(fc.timers) {
+		fc.mu.Unlock()
+		panic(fmt.Sprintf("fakeClock.Fire(%d): only %d timers registered", i, len(fc.timers)))
+	}
 	ft := fc.timers[i]
 	fc.mu.Unlock()
 	ft.fn()
@@ -110,6 +115,9 @@ func (fc *fakeClock) Fire(i int) {
 func (fc *fakeClock) Duration(i int) time.Duration {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
+	if i >= len(fc.timers) {
+		panic(fmt.Sprintf("fakeClock.Duration(%d): only %d timers registered", i, len(fc.timers)))
+	}
 	return fc.timers[i].d
 }
 
@@ -203,7 +211,10 @@ func TestServer_OnMessage_CallbackFires(t *testing.T) {
 	t.Cleanup(srv.Close)
 	c := dialTestServer(t, srv)
 	payload := []byte(`{"text":"ping from client"}`)
-	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "msg", Payload: payload})
+	encoded, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "msg", Payload: payload})
+	if err != nil {
+		t.Fatalf("JSONCodec.Encode failed: %v", err)
+	}
 	if err := c.WriteMessage(websocket.TextMessage, encoded); err != nil {
 		t.Fatalf("WriteMessage failed: %v", err)
 	}
@@ -705,7 +716,10 @@ func TestServer_ReadPumpPanicRecovery(t *testing.T) {
 	t.Cleanup(srv.Close)
 	c := dialTestServer(t, srv)
 
-	data, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
+	data, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
+	if err != nil {
+		t.Fatalf("JSONCodec.Encode failed: %v", err)
+	}
 	_ = c.WriteMessage(websocket.TextMessage, data)
 
 	select {
@@ -1438,7 +1452,10 @@ func TestServer_ReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
 		t.Fatalf("WriteMessage (malformed) failed: %v", err)
 	}
 	// Send a valid frame after the malformed one — readPump should continue.
-	validData, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "valid"})
+	validData, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "valid"})
+	if err != nil {
+		t.Fatalf("JSONCodec.Encode failed: %v", err)
+	}
 	if err := c.WriteMessage(websocket.TextMessage, validData); err != nil {
 		t.Fatalf("WriteMessage (valid) failed: %v", err)
 	}
@@ -2226,7 +2243,10 @@ func TestServer_NoOnMessage_ReadPumpStillProcesses(t *testing.T) {
 	c := dialTestServer(t, srv)
 
 	// Send a frame — readPump should process without crash.
-	data, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "ignored"})
+	data, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "ignored"})
+	if err != nil {
+		t.Fatalf("JSONCodec.Encode failed: %v", err)
+	}
 	if err := c.WriteMessage(websocket.TextMessage, data); err != nil {
 		t.Fatalf("WriteMessage failed: %v", err)
 	}
@@ -3493,7 +3513,10 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 	}
 
 	// Now send a message on the new transport.
-	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "ping"})
+	encoded, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "ping"})
+	if err != nil {
+		t.Fatalf("JSONCodec.Encode failed: %v", err)
+	}
 	if err := c2.WriteMessage(websocket.TextMessage, encoded); err != nil {
 		t.Fatalf("WriteMessage failed: %v", err)
 	}

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -63,7 +63,7 @@ type fakeTimer struct {
 func newFakeClock() *fakeClock { return &fakeClock{} }
 
 func (fc *fakeClock) AfterFunc(d time.Duration, f func()) *time.Timer {
-	t := time.NewTimer(time.Hour)
+	t := time.AfterFunc(time.Hour, f)
 	t.Stop()
 	fc.mu.Lock()
 	fc.timers = append(fc.timers, &fakeTimer{d: d, fn: f, timer: t})

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -47,6 +47,49 @@ func dialTestServerRaw(t *testing.T, srv wspulse.Server) (*websocket.Conn, *http
 	return c, ts
 }
 
+// ── Fake clock for grace-timer tests ─────────────────────────────────────────
+
+type fakeClock struct {
+	mu     sync.Mutex
+	timers []*fakeTimer
+}
+
+type fakeTimer struct {
+	d     time.Duration
+	fn    func()
+	timer *time.Timer
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{} }
+
+func (fc *fakeClock) AfterFunc(d time.Duration, f func()) *time.Timer {
+	t := time.NewTimer(time.Hour)
+	t.Stop()
+	fc.mu.Lock()
+	fc.timers = append(fc.timers, &fakeTimer{d: d, fn: f, timer: t})
+	fc.mu.Unlock()
+	return t
+}
+
+func (fc *fakeClock) NewTicker(d time.Duration) *time.Ticker {
+	return time.NewTicker(d)
+}
+
+// Fire executes the callback of the i-th registered AfterFunc (0-based).
+func (fc *fakeClock) Fire(i int) {
+	fc.mu.Lock()
+	ft := fc.timers[i]
+	fc.mu.Unlock()
+	ft.fn()
+}
+
+// Len returns the number of registered timers.
+func (fc *fakeClock) Len() int {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return len(fc.timers)
+}
+
 // ── Codec error path tests ───────────────────────────────────────────────────
 
 // failingCodec is a Codec that always returns an error on Encode.
@@ -837,13 +880,22 @@ func TestServer_Resume_ReconnectWithinWindow(t *testing.T) {
 func TestServer_Resume_GraceExpires_FiresOnDisconnect(t *testing.T) {
 	disconnected := make(chan struct{}, 1)
 	connected := make(chan struct{}, 1)
+	dropped := make(chan struct{}, 1)
+	fc := newFakeClock()
 
 	srv := wspulse.NewServer(
 		acceptAll,
-		wspulse.WithResumeWindow(time.Second),
+		wspulse.WithResumeWindow(3*time.Minute),
+		wspulse.WithClock(fc),
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
 			select {
 			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
 			default:
 			}
 		}),
@@ -864,6 +916,14 @@ func TestServer_Resume_GraceExpires_FiresOnDisconnect(t *testing.T) {
 	}
 
 	_ = c.Close()
+
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	fc.Fire(0)
 
 	select {
 	case <-disconnected:
@@ -1318,13 +1378,22 @@ func TestServer_Resume_StaleClosedSession_Reconnect(t *testing.T) {
 	// expire (session becomes closed), then reconnect with the same ID.
 	connected := make(chan struct{}, 4)
 	disconnected := make(chan struct{}, 4)
+	dropped := make(chan struct{}, 4)
+	fc := newFakeClock()
 
 	srv := wspulse.NewServer(
 		acceptAll,
-		wspulse.WithResumeWindow(1*time.Second), // 1-second window
+		wspulse.WithResumeWindow(3*time.Minute),
+		wspulse.WithClock(fc),
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
 			select {
 			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
 			default:
 			}
 		}),
@@ -1344,11 +1413,19 @@ func TestServer_Resume_StaleClosedSession_Reconnect(t *testing.T) {
 		t.Fatal("timed out waiting for first connect")
 	}
 
-	// Close transport and wait for grace to expire.
+	// Close transport and fire the grace timer.
 	_ = c1.Close()
 	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	fc.Fire(0)
+
+	select {
 	case <-disconnected:
-	case <-time.After(5 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for grace expiry disconnect")
 	}
 
@@ -2425,13 +2502,22 @@ func TestServer_ConnectionClose_StateClosed_TransportDied(t *testing.T) {
 func TestServer_Resume_GraceTimerFiresAfterReconnect(t *testing.T) {
 	connected := make(chan struct{}, 1)
 	disconnected := make(chan struct{}, 1)
+	dropped := make(chan struct{}, 1)
+	fc := newFakeClock()
 
 	srv := wspulse.NewServer(
 		acceptAll,
-		wspulse.WithResumeWindow(1*time.Second), // minimum 1s
+		wspulse.WithResumeWindow(3*time.Minute),
+		wspulse.WithClock(fc),
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
 			select {
 			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(connection wspulse.Connection, err error) {
+			select {
+			case dropped <- struct{}{}:
 			default:
 			}
 		}),
@@ -2452,12 +2538,15 @@ func TestServer_Resume_GraceTimerFiresAfterReconnect(t *testing.T) {
 		t.Fatal("timed out waiting for first connect")
 	}
 
-	// Disconnect (triggers suspend + 1s grace timer).
+	// Disconnect (triggers suspend + grace timer via fakeClock).
 	_ = c1.Close()
-	time.Sleep(200 * time.Millisecond)
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnTransportDrop")
+	}
 
-	// Reconnect before the grace timer fires. Resume does not fire
-	// onConnect — it only calls attachWS, so we verify via Send instead.
+	// Reconnect before firing the grace timer.
 	u := "ws" + strings.TrimPrefix(ts.URL, "http")
 	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
 	c2, _, err := dialer.Dial(u, nil)
@@ -2467,9 +2556,10 @@ func TestServer_Resume_GraceTimerFiresAfterReconnect(t *testing.T) {
 	t.Cleanup(func() { _ = c2.Close() })
 	time.Sleep(200 * time.Millisecond)
 
-	// Wait for the grace timer to fire (1s window + margin).
-	// The timer should find the session in stateConnected and skip.
-	time.Sleep(1500 * time.Millisecond)
+	// Fire the grace timer — session is already resumed (stateConnected),
+	// so handleGraceExpired should skip it.
+	fc.Fire(0)
+	time.Sleep(50 * time.Millisecond)
 
 	// Session should still be alive — verify by sending a frame.
 	frame := wspulse.Frame{Event: "still-alive", Payload: []byte(`"ok"`)}

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -106,6 +106,13 @@ func (fc *fakeClock) Fire(i int) {
 	ft.fn()
 }
 
+// Duration returns the duration passed to the i-th AfterFunc call.
+func (fc *fakeClock) Duration(i int) time.Duration {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return fc.timers[i].d
+}
+
 // TimerCount returns the number of registered AfterFunc timers.
 func (fc *fakeClock) TimerCount() int {
 	fc.mu.Lock()
@@ -978,6 +985,11 @@ func TestServer_Resume_GraceExpires_FiresOnDisconnect(t *testing.T) {
 	case <-dropped:
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for OnTransportDrop")
+	}
+
+	// Verify the grace timer was registered with the correct duration.
+	if got := fc.Duration(0); got != 3*time.Minute {
+		t.Fatalf("grace timer duration: want %v, got %v", 3*time.Minute, got)
 	}
 
 	fc.Fire(0)

--- a/server_test.go
+++ b/server_test.go
@@ -17,6 +17,7 @@ func acceptAll(r *http.Request) (roomID, connectionID string, err error) {
 }
 
 func TestServer_Send_ErrConnectionNotFound(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	t.Cleanup(srv.Close)
 	err := srv.Send("does-not-exist", wspulse.Frame{Event: "ping"})
@@ -26,6 +27,7 @@ func TestServer_Send_ErrConnectionNotFound(t *testing.T) {
 }
 
 func TestServer_Kick_ErrConnectionNotFound(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	t.Cleanup(srv.Close)
 	err := srv.Kick("does-not-exist")
@@ -35,6 +37,7 @@ func TestServer_Kick_ErrConnectionNotFound(t *testing.T) {
 }
 
 func TestServer_GetConnections_UnknownRoom_ReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	t.Cleanup(srv.Close)
 	connections := srv.GetConnections("no-such-room")
@@ -44,12 +47,14 @@ func TestServer_GetConnections_UnknownRoom_ReturnsEmptySlice(t *testing.T) {
 }
 
 func TestServer_Close_SafeToCallTwice(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	srv.Close() // first call
 	srv.Close() // must not panic
 }
 
 func TestWithCodec_Nil_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for nil codec")
@@ -59,6 +64,7 @@ func TestWithCodec_Nil_Panics(t *testing.T) {
 }
 
 func TestWithHeartbeat_InvalidParams_Panics(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name       string
 		ping, pong time.Duration
@@ -81,6 +87,7 @@ func TestWithHeartbeat_InvalidParams_Panics(t *testing.T) {
 }
 
 func TestNewServer_NilConnect_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for nil ConnectFunc")
@@ -90,6 +97,7 @@ func TestNewServer_NilConnect_Panics(t *testing.T) {
 }
 
 func TestWithLogger_Nil_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for nil logger")
@@ -99,6 +107,7 @@ func TestWithLogger_Nil_Panics(t *testing.T) {
 }
 
 func TestWithMaxMessageSize_Zero_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for zero max message size")
@@ -110,6 +119,7 @@ func TestWithMaxMessageSize_Zero_Panics(t *testing.T) {
 // ── Option validation tests ───────────────────────────────────────────────────
 
 func TestWithHeartbeat_ValidParams_Accepted(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithHeartbeat(5*time.Second, 15*time.Second),
 	)
@@ -117,6 +127,7 @@ func TestWithHeartbeat_ValidParams_Accepted(t *testing.T) {
 }
 
 func TestWithHeartbeat_PingExceedsMax_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for pingPeriod > 5m")
@@ -126,6 +137,7 @@ func TestWithHeartbeat_PingExceedsMax_Panics(t *testing.T) {
 }
 
 func TestWithHeartbeat_PongExceedsMax_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for pongWait > 10m")
@@ -135,6 +147,7 @@ func TestWithHeartbeat_PongExceedsMax_Panics(t *testing.T) {
 }
 
 func TestWithWriteWait_ValidDuration_Accepted(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithWriteWait(5*time.Second),
 	)
@@ -142,6 +155,7 @@ func TestWithWriteWait_ValidDuration_Accepted(t *testing.T) {
 }
 
 func TestWithWriteWait_Zero_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for zero write wait")
@@ -151,6 +165,7 @@ func TestWithWriteWait_Zero_Panics(t *testing.T) {
 }
 
 func TestWithWriteWait_ExceedsMax_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for write wait > 30s")
@@ -160,6 +175,7 @@ func TestWithWriteWait_ExceedsMax_Panics(t *testing.T) {
 }
 
 func TestWithMaxMessageSize_ValidSize_Accepted(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithMaxMessageSize(4096),
 	)
@@ -167,6 +183,7 @@ func TestWithMaxMessageSize_ValidSize_Accepted(t *testing.T) {
 }
 
 func TestWithMaxMessageSize_ExceedsMax_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for size > 64 MiB")
@@ -176,6 +193,7 @@ func TestWithMaxMessageSize_ExceedsMax_Panics(t *testing.T) {
 }
 
 func TestWithSendBufferSize_Zero_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for zero buffer size")
@@ -185,6 +203,7 @@ func TestWithSendBufferSize_Zero_Panics(t *testing.T) {
 }
 
 func TestWithSendBufferSize_ExceedsMax_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for buffer size > 4096")
@@ -194,6 +213,7 @@ func TestWithSendBufferSize_ExceedsMax_Panics(t *testing.T) {
 }
 
 func TestWithCheckOrigin_Nil_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for nil CheckOrigin")
@@ -203,6 +223,7 @@ func TestWithCheckOrigin_Nil_Panics(t *testing.T) {
 }
 
 func TestWithResumeWindow_Negative_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for negative resume window")
@@ -212,6 +233,7 @@ func TestWithResumeWindow_Negative_Panics(t *testing.T) {
 }
 
 func TestWithResumeWindow_ExceedsMax_Panics(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for resume window > 3m")
@@ -221,6 +243,7 @@ func TestWithResumeWindow_ExceedsMax_Panics(t *testing.T) {
 }
 
 func TestWithCodec_ValidCodec_Accepted(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithCodec(wspulse.JSONCodec),
 	)
@@ -228,6 +251,7 @@ func TestWithCodec_ValidCodec_Accepted(t *testing.T) {
 }
 
 func TestWithLogger_ValidLogger_Accepted(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithLogger(zaptest.NewLogger(t)),
 	)
@@ -237,6 +261,7 @@ func TestWithLogger_ValidLogger_Accepted(t *testing.T) {
 // ── Broadcast to empty or unknown room (already partially covered) ────────────
 
 func TestServer_Broadcast_EmptyRoom_NoError(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	t.Cleanup(srv.Close)
 	err := srv.Broadcast("nonexistent-room", wspulse.Frame{Event: "msg"})
@@ -248,6 +273,7 @@ func TestServer_Broadcast_EmptyRoom_NoError(t *testing.T) {
 // ── Kick and Broadcast during server shutdown ─────────────────────────────────
 
 func TestServer_Kick_AfterClose_ReturnsErrServerClosed(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	srv.Close()
 	if err := srv.Kick("any"); !errors.Is(err, wspulse.ErrServerClosed) {
@@ -258,6 +284,7 @@ func TestServer_Kick_AfterClose_ReturnsErrServerClosed(t *testing.T) {
 // ── Send/Kick during hub close (both ErrServerClosed paths) ──────────────────
 
 func TestServer_Send_AfterClose_ReturnsErrConnectionNotFound(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	srv.Close()
 	// After close, hub maps are empty — returns ErrConnectionNotFound.
@@ -270,6 +297,7 @@ func TestServer_Send_AfterClose_ReturnsErrConnectionNotFound(t *testing.T) {
 // TestServer_Broadcast_AfterClose verifies Broadcast returns ErrServerClosed
 // when called after the server has been closed.
 func TestServer_Broadcast_AfterClose(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	srv.Close()
 	err := srv.Broadcast("test-room", wspulse.Frame{Event: "hello"})
@@ -281,6 +309,7 @@ func TestServer_Broadcast_AfterClose(t *testing.T) {
 // TestServer_Kick_AfterClose verifies Kick returns ErrServerClosed
 // when called after the server has been closed.
 func TestServer_Kick_AfterClose(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll)
 	srv.Close()
 	err := srv.Kick("test-connection")
@@ -290,6 +319,7 @@ func TestServer_Kick_AfterClose(t *testing.T) {
 }
 
 func TestWithOnTransportDrop_AcceptsNil(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithOnTransportDrop(nil),
 	)
@@ -297,6 +327,7 @@ func TestWithOnTransportDrop_AcceptsNil(t *testing.T) {
 }
 
 func TestWithOnTransportRestore_AcceptsNil(t *testing.T) {
+	t.Parallel()
 	srv := wspulse.NewServer(acceptAll,
 		wspulse.WithOnTransportRestore(nil),
 	)

--- a/server_test.go
+++ b/server_test.go
@@ -289,6 +289,20 @@ func TestServer_Kick_AfterClose(t *testing.T) {
 	}
 }
 
+func TestWithOnTransportDrop_AcceptsNil(t *testing.T) {
+	srv := wspulse.NewServer(acceptAll,
+		wspulse.WithOnTransportDrop(nil),
+	)
+	t.Cleanup(srv.Close)
+}
+
+func TestWithOnTransportRestore_AcceptsNil(t *testing.T) {
+	srv := wspulse.NewServer(acceptAll,
+		wspulse.WithOnTransportRestore(nil),
+	)
+	t.Cleanup(srv.Close)
+}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -232,14 +232,12 @@ func TestWithResumeWindow_Negative_Panics(t *testing.T) {
 	_ = wspulse.WithResumeWindow(-time.Second)
 }
 
-func TestWithResumeWindow_ExceedsMax_Panics(t *testing.T) {
+func TestWithResumeWindow_LargeValue_Accepted(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for resume window > 3m")
-		}
-	}()
-	_ = wspulse.WithResumeWindow(3*time.Minute + time.Second)
+	srv := wspulse.NewServer(acceptAll,
+		wspulse.WithResumeWindow(10*time.Minute),
+	)
+	srv.Close()
 }
 
 func TestWithCodec_ValidCodec_Accepted(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -211,6 +211,11 @@ func (s *session) Close() error {
 // buffered frames are drained into the send channel before the new
 // writePump starts.
 //
+// onResumeComplete, if non-nil, is invoked in a separate goroutine after
+// the resume drain completes and both pumps have started. This ensures
+// the callback fires only when the session is in stateConnected with
+// active pumps. Pass nil for new (non-resume) sessions.
+//
 // The method returns immediately without blocking the caller (the hub's
 // event loop). A transition goroutine waits for the old writePump to exit,
 // drains the resume buffer, and then starts both readPump and writePump.
@@ -231,7 +236,7 @@ func (s *session) Close() error {
 // all pre-resume frames precede post-resume frames in s.send.
 //
 // Must be called from the hub's event loop (single-goroutine serialization).
-func (s *session) attachWS(transport *websocket.Conn, h *hub) {
+func (s *session) attachWS(transport *websocket.Conn, h *hub, onResumeComplete func()) {
 	s.mu.Lock()
 
 	// Stop the previous pump pair if still running.
@@ -349,6 +354,10 @@ func (s *session) attachWS(transport *websocket.Conn, h *hub) {
 
 		go s.readPump(transport, h)
 		go s.writePump(transport, pumpQuit, pumpDone)
+
+		if onResumeComplete != nil {
+			go onResumeComplete()
+		}
 	}()
 }
 

--- a/session.go
+++ b/session.go
@@ -356,7 +356,12 @@ func (s *session) attachWS(transport *websocket.Conn, h *hub, onResumeComplete f
 		go s.writePump(transport, pumpQuit, pumpDone)
 
 		if onResumeComplete != nil {
-			go onResumeComplete()
+			s.mu.Lock()
+			shouldCall := s.state == stateConnected && s.transport == transport
+			s.mu.Unlock()
+			if shouldCall {
+				go onResumeComplete()
+			}
 		}
 	}()
 }

--- a/session.go
+++ b/session.go
@@ -468,7 +468,7 @@ func (s *session) readPump(transport *websocket.Conn, h *hub) {
 // pumpQuit is closed when this pump should stop (reconnect or session close).
 // pumpDone is closed on exit so callers can wait for this pump to finish.
 func (s *session) writePump(transport *websocket.Conn, pumpQuit, pumpDone chan struct{}) {
-	ticker := time.NewTicker(s.config.pingPeriod)
+	ticker := s.config.clock.NewTicker(s.config.pingPeriod)
 	defer func() {
 		ticker.Stop()
 		_ = transport.Close()


### PR DESCRIPTION
## Summary
- Add `WithOnTransportDrop(fn func(Connection, error))` and `WithOnTransportRestore(fn func(Connection))` server options
- `OnTransportDrop` fires when transport dies and session enters suspended state (`resumeWindow > 0`)
- `OnTransportRestore` fires when a suspended session resumes via reconnect
- Neither fires when `resumeWindow` is not configured
- Both run in separate goroutines, consistent with `OnConnect`/`OnDisconnect`

## Test plan
- [x] Unit tests: `TestWithOnTransportDrop_AcceptsNil`, `TestWithOnTransportRestore_AcceptsNil`
- [x] Integration: `TestOnTransportDrop_FiresOnSuspend` (scenario 11)
- [x] Integration: `TestOnTransportRestore_FiresOnResume` (scenario 12)
- [x] Integration: `TestTransportCallbacks_NotFired_WithoutResumeWindow` (scenario 13)
- [x] Integration: `TestOnTransportDrop_GraceExpires_ThenDisconnect` (ordering)
- [x] Integration: `TestOnTransportRestore_ThenOnMessage` (ordering)
- [x] `make check` passes
- [x] `make test-integration` passes