### PR TITLE
refactor: eng review improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `PanicError` exported type — wraps panics recovered from `OnMessage` handlers with the panic value and goroutine stack trace; passed to `OnDisconnect` so applications can distinguish handler panics from transport failures via `errors.As`
+- `WithUpgraderBufferSize(readSize, writeSize int)` option — configures the WebSocket upgrader I/O buffer sizes (default 1024 bytes each)
+- Benchmarks for ring buffer, broadcast fan-out, direct Send throughput, and drop-oldest backpressure
+
+### Changed
+
+- Broadcast fan-out reuses a scratch slice on the hub instead of allocating a new snapshot per invocation — zero-alloc steady state since the hub event loop is single-threaded
+- `ConnectFunc` GoDoc now documents that `roomID` is ignored on session resumption
+
+### Fixed
+
+- `ServeHTTP` no longer leaks the `ConnectFunc` error message to the HTTP 401 response body — returns a generic `"unauthorized"` string instead
+
 ## [0.4.0] - 2026-03-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `PanicError` exported type — wraps panics recovered from `OnMessage` handlers with the panic value and goroutine stack trace; passed to `OnDisconnect` so applications can distinguish handler panics from transport failures via `errors.As`
+- `PanicError` exported type — wraps panics recovered from `OnMessage` handlers with the panic value and goroutine stack trace; delivered to `OnDisconnect` when resumption is disabled, or to `OnTransportDrop` when resumption is enabled (in which case `OnDisconnect` may later fire with a nil error); use `errors.As` on whichever callback error is non-nil to distinguish handler panics from transport failures
 - `WithUpgraderBufferSize(readSize, writeSize int)` option — configures the WebSocket upgrader I/O buffer sizes (default 1024 bytes each)
 - Benchmarks for ring buffer, broadcast fan-out, direct Send throughput, and drop-oldest backpressure
 

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -203,6 +203,10 @@ WS2 client reconnects with same connectionID
   → onTransportRestore fires; no onConnect / onDisconnect fired
 ```
 
+Note: on resume, the `roomID` returned by the new `ConnectFunc` call is
+ignored. The session retains its original room assignment from the initial
+connection.
+
 ### Resume Buffer
 
 During the suspended state, frames sent via `session.Send()` or

--- a/errors.go
+++ b/errors.go
@@ -25,13 +25,16 @@ var (
 
 // PanicError wraps a panic recovered from an OnMessage callback.
 // When an OnMessage handler panics, the readPump recovers the panic and
-// terminates the connection. The PanicError is passed to the OnDisconnect
-// callback so applications can distinguish transport failures from handler
-// panics using errors.As.
+// terminates the connection (or suspends it when session resumption is
+// enabled). The transport error (including PanicError) is reported to the
+// OnTransportDrop callback so applications can distinguish transport
+// failures from handler panics using errors.As.
 //
-// Behaviour: a panic in OnMessage always kills the connection (or suspends
-// it when session resumption is enabled). This is intentional — corrupted
-// handler state should not process further messages.
+// Behaviour: a panic in OnMessage always kills the connection. This is
+// intentional — corrupted handler state should not process further messages.
+// When resumption is enabled, OnDisconnect may later be invoked on grace
+// expiry with a nil error; callers must not rely on PanicError always being
+// delivered via OnDisconnect.
 type PanicError struct {
 	// Value is the value passed to panic().
 	Value any

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package wspulse
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Server-only sentinel errors. Shared errors (ErrConnectionClosed,
 // ErrSendBufferFull) live in github.com/wspulse/core and are re-exported
@@ -19,3 +22,23 @@ var (
 	// other methods) when the Server has already been shut down via Close().
 	ErrServerClosed = errors.New("wspulse: server is closed")
 )
+
+// PanicError wraps a panic recovered from an OnMessage callback.
+// When an OnMessage handler panics, the readPump recovers the panic and
+// terminates the connection. The PanicError is passed to the OnDisconnect
+// callback so applications can distinguish transport failures from handler
+// panics using errors.As.
+//
+// Behaviour: a panic in OnMessage always kills the connection (or suspends
+// it when session resumption is enabled). This is intentional — corrupted
+// handler state should not process further messages.
+type PanicError struct {
+	// Value is the value passed to panic().
+	Value any
+	// Stack is the goroutine stack trace captured at the point of recovery.
+	Stack []byte
+}
+
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("wspulse: onMessage panic: %v", e.Value)
+}

--- a/errors.go
+++ b/errors.go
@@ -26,15 +26,22 @@ var (
 // PanicError wraps a panic recovered from an OnMessage callback.
 // When an OnMessage handler panics, the readPump recovers the panic and
 // terminates the connection (or suspends it when session resumption is
-// enabled). The transport error (including PanicError) is reported to the
-// OnTransportDrop callback so applications can distinguish transport
-// failures from handler panics using errors.As.
+// enabled).
+//
+// Delivery:
+//   - When resumption is disabled (resumeWindow == 0, the default), the
+//     connection is closed immediately and the PanicError is delivered via
+//     the OnDisconnect callback's error parameter. OnTransportDrop is not
+//     invoked in this mode.
+//   - When resumption is enabled (resumeWindow > 0), the transport error
+//     (including PanicError) is reported to the OnTransportDrop callback so
+//     applications can distinguish transport failures from handler panics
+//     using errors.As. OnDisconnect may later be invoked on grace expiry
+//     with a nil error; callers must not rely on PanicError always being
+//     delivered via OnDisconnect.
 //
 // Behaviour: a panic in OnMessage always kills the connection. This is
 // intentional — corrupted handler state should not process further messages.
-// When resumption is enabled, OnDisconnect may later be invoked on grace
-// expiry with a nil error; callers must not rely on PanicError always being
-// delivered via OnDisconnect.
 type PanicError struct {
 	// Value is the value passed to panic().
 	Value any

--- a/hub.go
+++ b/hub.go
@@ -69,7 +69,8 @@ type hub struct {
 	done          chan struct{} // closed by Server.Close()
 
 	mu      sync.RWMutex
-	stopped atomic.Bool // set by shutdown(); ServeHTTP checks this early
+	stopped atomic.Bool    // set by shutdown(); ServeHTTP checks this early
+	scratch []*session     // reusable slice for broadcast snapshot; avoids per-broadcast allocation
 	config  *serverConfig
 }
 
@@ -376,23 +377,25 @@ func (h *hub) handleKick(request kickRequest) {
 }
 
 // handleBroadcast fans out pre-encoded data to every session in the room.
+// Uses h.scratch to avoid allocating a snapshot slice per broadcast.
+// Safe because the hub event loop is single-threaded.
 func (h *hub) handleBroadcast(message broadcastMessage) {
 	h.mu.RLock()
 	room := h.rooms[message.roomID]
-	sessions := make([]*session, 0, len(room))
+	h.scratch = h.scratch[:0]
 	for _, s := range room {
-		sessions = append(sessions, s)
+		h.scratch = append(h.scratch, s)
 	}
 	h.mu.RUnlock()
 
-	if len(sessions) == 0 {
+	if len(h.scratch) == 0 {
 		h.config.logger.Debug("wspulse: broadcast to empty/unknown room",
 			zap.String("room_id", message.roomID),
 		)
 		return
 	}
 
-	for _, target := range sessions {
+	for _, target := range h.scratch {
 		select {
 		case <-target.done:
 			continue
@@ -405,7 +408,7 @@ func (h *hub) handleBroadcast(message broadcastMessage) {
 	}
 	h.config.logger.Debug("wspulse: broadcast dispatched",
 		zap.String("room_id", message.roomID),
-		zap.Int("recipients", len(sessions)),
+		zap.Int("recipients", len(h.scratch)),
 	)
 }
 

--- a/hub.go
+++ b/hub.go
@@ -410,6 +410,13 @@ func (h *hub) handleBroadcast(message broadcastMessage) {
 		zap.String("room_id", message.roomID),
 		zap.Int("recipients", len(h.scratch)),
 	)
+
+	// Clear pointers so disconnected sessions can be GC'd.
+	// Without this, the backing array retains stale *session pointers
+	// in its capacity area after h.scratch[:0] on the next broadcast.
+	for i := range h.scratch {
+		h.scratch[i] = nil
+	}
 }
 
 // disconnectSession removes the session from hub maps, closes it, and fires

--- a/hub.go
+++ b/hub.go
@@ -69,8 +69,8 @@ type hub struct {
 	done          chan struct{} // closed by Server.Close()
 
 	mu      sync.RWMutex
-	stopped atomic.Bool    // set by shutdown(); ServeHTTP checks this early
-	scratch []*session     // reusable slice for broadcast snapshot; avoids per-broadcast allocation
+	stopped atomic.Bool // set by shutdown(); ServeHTTP checks this early
+	scratch []*session  // reusable slice for broadcast snapshot; avoids per-broadcast allocation
 	config  *serverConfig
 }
 

--- a/options.go
+++ b/options.go
@@ -23,10 +23,11 @@ const (
 // has a unique, non-empty ID. Use a non-empty connectionID when the application needs
 // deterministic IDs (e.g. for Server.Send and Server.Kick).
 //
-// On session resumption (reconnect within the resume window), the roomID
-// returned by ConnectFunc is ignored — the session retains its original room
-// assignment from the initial connection. Only the first ConnectFunc call for
-// a given connectionID determines the room.
+// On session resumption (reconnect of a suspended session within the resume
+// window), the roomID returned by ConnectFunc is ignored — the session retains
+// its original room assignment from the initial connection. For new sessions
+// (including when a duplicate connectionID replaces an existing connected
+// session), the roomID from ConnectFunc determines the room.
 type ConnectFunc func(r *http.Request) (roomID, connectionID string, err error)
 
 // ServerOption configures a Server.

--- a/options.go
+++ b/options.go
@@ -33,20 +33,20 @@ type ConnectFunc func(r *http.Request) (roomID, connectionID string, err error)
 type ServerOption func(*serverConfig) //nolint:revive
 
 type serverConfig struct {
-	connect            ConnectFunc
-	onConnect          func(Connection)
-	onMessage          func(Connection, Frame)
-	onDisconnect       func(Connection, error)
-	onTransportDrop    func(Connection, error)
-	onTransportRestore func(Connection)
-	pingPeriod         time.Duration
-	pongWait           time.Duration
-	writeWait          time.Duration
-	maxMessageSize     int64
-	sendBufferSize     int
-	resumeWindow       time.Duration // session resume grace period as a time.Duration (e.g. 5*time.Minute); 0 = disabled
-	codec              Codec
-	checkOrigin        func(r *http.Request) bool
+	connect                 ConnectFunc
+	onConnect               func(Connection)
+	onMessage               func(Connection, Frame)
+	onDisconnect            func(Connection, error)
+	onTransportDrop         func(Connection, error)
+	onTransportRestore      func(Connection)
+	pingPeriod              time.Duration
+	pongWait                time.Duration
+	writeWait               time.Duration
+	maxMessageSize          int64
+	sendBufferSize          int
+	resumeWindow            time.Duration // session resume grace period as a time.Duration (e.g. 5*time.Minute); 0 = disabled
+	codec                   Codec
+	checkOrigin             func(r *http.Request) bool
 	logger                  *zap.Logger
 	clock                   clock
 	upgraderReadBufferSize  int
@@ -55,15 +55,15 @@ type serverConfig struct {
 
 func defaultConfig(connect ConnectFunc) *serverConfig {
 	return &serverConfig{
-		connect:        connect,
-		pingPeriod:     10 * time.Second,
-		pongWait:       30 * time.Second,
-		writeWait:      10 * time.Second,
-		maxMessageSize: 512,
-		sendBufferSize: 256,
-		resumeWindow:   0,
-		codec:          JSONCodec,
-		checkOrigin:    func(*http.Request) bool { return true },
+		connect:                 connect,
+		pingPeriod:              10 * time.Second,
+		pongWait:                30 * time.Second,
+		writeWait:               10 * time.Second,
+		maxMessageSize:          512,
+		sendBufferSize:          256,
+		resumeWindow:            0,
+		codec:                   JSONCodec,
+		checkOrigin:             func(*http.Request) bool { return true },
 		logger:                  zap.NewNop(),
 		clock:                   realClock{},
 		upgraderReadBufferSize:  1024,

--- a/options.go
+++ b/options.go
@@ -47,8 +47,10 @@ type serverConfig struct {
 	resumeWindow       time.Duration // session resume grace period as a time.Duration (e.g. 5*time.Minute); 0 = disabled
 	codec              Codec
 	checkOrigin        func(r *http.Request) bool
-	logger             *zap.Logger
-	clock              clock
+	logger                  *zap.Logger
+	clock                   clock
+	upgraderReadBufferSize  int
+	upgraderWriteBufferSize int
 }
 
 func defaultConfig(connect ConnectFunc) *serverConfig {
@@ -62,8 +64,10 @@ func defaultConfig(connect ConnectFunc) *serverConfig {
 		resumeWindow:   0,
 		codec:          JSONCodec,
 		checkOrigin:    func(*http.Request) bool { return true },
-		logger:         zap.NewNop(),
-		clock:          realClock{},
+		logger:                  zap.NewNop(),
+		clock:                   realClock{},
+		upgraderReadBufferSize:  1024,
+		upgraderWriteBufferSize: 1024,
 	}
 }
 
@@ -227,4 +231,21 @@ func WithResumeWindow(d time.Duration) ServerOption {
 		panic("wspulse: WithResumeWindow: duration must be non-negative")
 	}
 	return func(c *serverConfig) { c.resumeWindow = d }
+}
+
+// WithUpgraderBufferSize sets the I/O buffer sizes for the WebSocket upgrader.
+// Larger buffers reduce per-write allocations for applications that send
+// large messages. Default: 1024 bytes for both read and write.
+// Panics if either size is not positive.
+func WithUpgraderBufferSize(readSize, writeSize int) ServerOption {
+	if readSize <= 0 {
+		panic("wspulse: WithUpgraderBufferSize: readSize must be positive")
+	}
+	if writeSize <= 0 {
+		panic("wspulse: WithUpgraderBufferSize: writeSize must be positive")
+	}
+	return func(c *serverConfig) {
+		c.upgraderReadBufferSize = readSize
+		c.upgraderWriteBufferSize = writeSize
+	}
 }

--- a/options.go
+++ b/options.go
@@ -18,10 +18,15 @@ const (
 
 // ConnectFunc authenticates an incoming HTTP upgrade request and provides the
 // roomID and connectionID for the new connection.
-// Returning a non-nil error rejects the upgrade with HTTP 401 and the error text as the body.
+// Returning a non-nil error rejects the upgrade with HTTP 401.
 // If connectionID is empty the Server assigns a random UUID so that every connection
 // has a unique, non-empty ID. Use a non-empty connectionID when the application needs
 // deterministic IDs (e.g. for Server.Send and Server.Kick).
+//
+// On session resumption (reconnect within the resume window), the roomID
+// returned by ConnectFunc is ignored — the session retains its original room
+// assignment from the initial connection. Only the first ConnectFunc call for
+// a given connectionID determines the room.
 type ConnectFunc func(r *http.Request) (roomID, connectionID string, err error)
 
 // ServerOption configures a Server.

--- a/resume_bench_test.go
+++ b/resume_bench_test.go
@@ -1,0 +1,26 @@
+package wspulse
+
+import "testing"
+
+func BenchmarkRingBuffer_Push(b *testing.B) {
+	rb := newRingBuffer(256)
+	frame := []byte(`{"event":"bench","payload":{}}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rb.Push(frame)
+	}
+}
+
+func BenchmarkRingBuffer_PushDrain(b *testing.B) {
+	rb := newRingBuffer(256)
+	frame := []byte(`{"event":"bench","payload":{}}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 256; j++ {
+			rb.Push(frame)
+		}
+		rb.Drain()
+	}
+}

--- a/server.go
+++ b/server.go
@@ -82,8 +82,8 @@ func NewServer(connect ConnectFunc, options ...ServerOption) Server {
 		hub:     h,
 		hubDone: hubDone,
 		upgrader: websocket.Upgrader{
-			ReadBufferSize:  1024,
-			WriteBufferSize: 1024,
+			ReadBufferSize:  config.upgraderReadBufferSize,
+			WriteBufferSize: config.upgraderWriteBufferSize,
 			CheckOrigin:     config.checkOrigin,
 		},
 	}

--- a/server.go
+++ b/server.go
@@ -110,7 +110,7 @@ func (s *internalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.config.logger.Debug("wspulse: connect rejected",
 			zap.Error(err),
 		)
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if connectionID == "" {

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package wspulse_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	wspulse "github.com/wspulse/server"
+)
+
+// benchAcceptN returns a ConnectFunc that assigns each connection to
+// "bench-room" with a unique sequential ID.
+func benchAcceptN() wspulse.ConnectFunc {
+	var mu sync.Mutex
+	var n int
+	return func(r *http.Request) (string, string, error) {
+		mu.Lock()
+		n++
+		id := fmt.Sprintf("conn-%d", n)
+		mu.Unlock()
+		return "bench-room", id, nil
+	}
+}
+
+// dialN connects n WebSocket clients to srv, returning the server
+// and all connections. Caller must close the server and connections.
+func dialN(b *testing.B, srv wspulse.Server, n int) (*httptest.Server, []*websocket.Conn) {
+	b.Helper()
+	ts := httptest.NewServer(srv)
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+
+	conns := make([]*websocket.Conn, n)
+	for i := range conns {
+		c, _, err := dialer.Dial(u, nil)
+		if err != nil {
+			b.Fatalf("Dial %d failed: %v", i, err)
+		}
+		conns[i] = c
+	}
+	return ts, conns
+}
+
+func BenchmarkBroadcast(b *testing.B) {
+	for _, roomSize := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("room_%d", roomSize), func(b *testing.B) {
+			benchBroadcast(b, roomSize)
+		})
+	}
+}
+
+func benchBroadcast(b *testing.B, roomSize int) {
+	connected := make(chan struct{}, roomSize)
+	srv := wspulse.NewServer(
+		benchAcceptN(),
+		wspulse.WithOnConnect(func(c wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+	)
+
+	ts, conns := dialN(b, srv, roomSize)
+	defer ts.Close()
+	defer srv.Close()
+	for _, c := range conns {
+		defer c.Close()
+	}
+
+	// Wait for all connections to register.
+	for i := 0; i < roomSize; i++ {
+		select {
+		case <-connected:
+		case <-time.After(5 * time.Second):
+			b.Fatalf("timed out waiting for connection %d", i)
+		}
+	}
+
+	frame := wspulse.Frame{Event: "bench", Payload: []byte(`{"v":1}`)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := srv.Broadcast("bench-room", frame); err != nil {
+			b.Fatalf("Broadcast: %v", err)
+		}
+	}
+}
+
+func BenchmarkSend(b *testing.B) {
+	var conn wspulse.Connection
+	connected := make(chan struct{}, 1)
+	srv := wspulse.NewServer(
+		func(r *http.Request) (string, string, error) {
+			return "bench-room", "bench-conn", nil
+		},
+		wspulse.WithOnConnect(func(c wspulse.Connection) {
+			conn = c
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+	)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	c, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		b.Fatalf("Dial failed: %v", err)
+	}
+	defer c.Close()
+
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		b.Fatal("timed out waiting for connect")
+	}
+
+	// Drain client side to prevent send buffer full.
+	go func() {
+		for {
+			_, _, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	frame := wspulse.Frame{Event: "bench", Payload: []byte(`{"v":1}`)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = conn.Send(frame)
+	}
+}
+
+func BenchmarkEnqueue_DropOldest(b *testing.B) {
+	connected := make(chan struct{}, 1)
+	srv := wspulse.NewServer(
+		func(r *http.Request) (string, string, error) {
+			return "bench-room", "bench-conn", nil
+		},
+		wspulse.WithOnConnect(func(c wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithSendBufferSize(1),
+	)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer srv.Close()
+
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	c, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		b.Fatalf("Dial failed: %v", err)
+	}
+	defer c.Close()
+
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		b.Fatal("timed out waiting for connect")
+	}
+
+	// Do NOT drain — let buffer fill so broadcast hits drop-oldest path.
+	frame := wspulse.Frame{Event: "bench", Payload: []byte(`{"v":1}`)}
+
+	// Pre-fill the buffer.
+	_ = srv.Broadcast("bench-room", frame)
+	time.Sleep(50 * time.Millisecond) // let hub process
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = srv.Broadcast("bench-room", frame)
+	}
+}

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package wspulse_test
 
 import (
@@ -73,7 +71,7 @@ func benchBroadcast(b *testing.B, roomSize int) {
 	defer ts.Close()
 	defer srv.Close()
 	for _, c := range conns {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 	}
 
 	// Wait for all connections to register.
@@ -109,6 +107,7 @@ func BenchmarkSend(b *testing.B) {
 			default:
 			}
 		}),
+		wspulse.WithSendBufferSize(4096), // large buffer to avoid filling during benchmark
 	)
 
 	ts := httptest.NewServer(srv)
@@ -121,7 +120,7 @@ func BenchmarkSend(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Dial failed: %v", err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	select {
 	case <-connected:
@@ -143,17 +142,22 @@ func BenchmarkSend(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// ErrSendBufferFull is expected at benchmark speed — the drain
+		// goroutine cannot keep up with the enqueue rate. The benchmark
+		// measures raw encode+enqueue cost including both paths.
 		_ = conn.Send(frame)
 	}
 }
 
 func BenchmarkEnqueue_DropOldest(b *testing.B) {
+	var conn wspulse.Connection
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewServer(
 		func(r *http.Request) (string, string, error) {
 			return "bench-room", "bench-conn", nil
 		},
 		wspulse.WithOnConnect(func(c wspulse.Connection) {
+			conn = c
 			select {
 			case connected <- struct{}{}:
 			default:
@@ -172,7 +176,7 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Dial failed: %v", err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	select {
 	case <-connected:
@@ -181,15 +185,18 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 	}
 
 	// Do NOT drain — let buffer fill so broadcast hits drop-oldest path.
+	// Pre-fill the send buffer via direct Send (bypasses hub, synchronous
+	// enqueue) to avoid a racy sleep.
 	frame := wspulse.Frame{Event: "bench", Payload: []byte(`{"v":1}`)}
-
-	// Pre-fill the buffer.
-	_ = srv.Broadcast("bench-room", frame)
-	time.Sleep(50 * time.Millisecond) // let hub process
+	if err := conn.Send(frame); err != nil {
+		b.Fatalf("prefill Send failed: %v", err)
+	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = srv.Broadcast("bench-room", frame)
+		if err := srv.Broadcast("bench-room", frame); err != nil {
+			b.Fatalf("Broadcast failed: %v", err)
+		}
 	}
 }

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -68,10 +68,11 @@ func benchBroadcast(b *testing.B, roomSize int) {
 	)
 
 	ts, conns := dialN(b, srv, roomSize)
-	defer ts.Close()
-	defer srv.Close()
+	b.Cleanup(ts.Close)
+	b.Cleanup(srv.Close)
 	for _, c := range conns {
-		defer func() { _ = c.Close() }()
+		conn := c
+		b.Cleanup(func() { _ = conn.Close() })
 	}
 
 	// Wait for all connections to register.
@@ -111,8 +112,8 @@ func BenchmarkSend(b *testing.B) {
 	)
 
 	ts := httptest.NewServer(srv)
-	defer ts.Close()
-	defer srv.Close()
+	b.Cleanup(ts.Close)
+	b.Cleanup(srv.Close)
 
 	u := "ws" + strings.TrimPrefix(ts.URL, "http")
 	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
@@ -120,7 +121,7 @@ func BenchmarkSend(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Dial failed: %v", err)
 	}
-	defer func() { _ = c.Close() }()
+	b.Cleanup(func() { _ = c.Close() })
 
 	select {
 	case <-connected:
@@ -167,8 +168,8 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 	)
 
 	ts := httptest.NewServer(srv)
-	defer ts.Close()
-	defer srv.Close()
+	b.Cleanup(ts.Close)
+	b.Cleanup(srv.Close)
 
 	u := "ws" + strings.TrimPrefix(ts.URL, "http")
 	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
@@ -176,7 +177,7 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Dial failed: %v", err)
 	}
-	defer func() { _ = c.Close() }()
+	b.Cleanup(func() { _ = c.Close() })
 
 	select {
 	case <-connected:

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -108,7 +108,7 @@ func BenchmarkSend(b *testing.B) {
 			default:
 			}
 		}),
-		wspulse.WithSendBufferSize(4096), // large buffer to avoid filling during benchmark
+		wspulse.WithSendBufferSize(4096), // larger buffer to reduce send-buffer-full frequency
 	)
 
 	ts := httptest.NewServer(srv)

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -5,6 +5,7 @@ package wspulse_test
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -160,7 +161,7 @@ func (failingCodec) FrameType() int { return wspulse.TextMessage }
 func TestServer_ConnectFunc_RejectReturns401(t *testing.T) {
 	t.Parallel()
 	srv := wspulse.NewServer(func(r *http.Request) (string, string, error) {
-		return "", "", errors.New("unauthorized")
+		return "", "", errors.New("internal: db connection pool exhausted")
 	})
 	t.Cleanup(srv.Close)
 	ts := httptest.NewServer(srv)
@@ -172,6 +173,10 @@ func TestServer_ConnectFunc_RejectReturns401(t *testing.T) {
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("want 401, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if got := strings.TrimSpace(string(body)); got != "unauthorized" {
+		t.Errorf("response body = %q, want %q (internal error must not leak)", got, "unauthorized")
 	}
 }
 

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -174,7 +174,10 @@ func TestServer_ConnectFunc_RejectReturns401(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("want 401, got %d", resp.StatusCode)
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
 	if got := strings.TrimSpace(string(body)); got != "unauthorized" {
 		t.Errorf("response body = %q, want %q (internal error must not leak)", got, "unauthorized")
 	}
@@ -756,7 +759,9 @@ func TestServer_ReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("JSONCodec.Encode failed: %v", err)
 	}
-	_ = c.WriteMessage(websocket.TextMessage, data)
+	if err := c.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("WriteMessage failed: %v", err)
+	}
 
 	select {
 	case got := <-disconnectErr:

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -734,6 +734,51 @@ func TestServer_ReadPumpPanicRecovery(t *testing.T) {
 	}
 }
 
+func TestServer_ReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
+	t.Parallel()
+	disconnectErr := make(chan error, 1)
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithOnMessage(func(connection wspulse.Connection, f wspulse.Frame) {
+			panic("typed-boom")
+		}),
+		wspulse.WithOnDisconnect(func(connection wspulse.Connection, err error) {
+			select {
+			case disconnectErr <- err:
+			default:
+			}
+		}),
+	)
+	t.Cleanup(srv.Close)
+	c := dialTestServer(t, srv)
+
+	data, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
+	if err != nil {
+		t.Fatalf("JSONCodec.Encode failed: %v", err)
+	}
+	_ = c.WriteMessage(websocket.TextMessage, data)
+
+	select {
+	case got := <-disconnectErr:
+		var pe *wspulse.PanicError
+		if !errors.As(got, &pe) {
+			t.Fatalf("expected PanicError, got %T: %v", got, got)
+		}
+		if pe.Value != "typed-boom" {
+			t.Fatalf("PanicError.Value = %v, want %q", pe.Value, "typed-boom")
+		}
+		if len(pe.Stack) == 0 {
+			t.Fatal("PanicError.Stack is empty, expected goroutine stack trace")
+		}
+		want := "wspulse: onMessage panic: typed-boom"
+		if pe.Error() != want {
+			t.Fatalf("PanicError.Error() = %q, want %q", pe.Error(), want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnDisconnect")
+	}
+}
+
 func TestServer_ConnectionSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T) {
 	t.Parallel()
 	connected := make(chan wspulse.Connection, 1)

--- a/server_test.go
+++ b/server_test.go
@@ -2,7 +2,10 @@ package wspulse_test
 
 import (
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -356,6 +359,36 @@ func TestWithUpgraderBufferSize_ValidSizes_Accepted(t *testing.T) {
 	t.Parallel()
 	srv := wspulse.NewServer(acceptAll, wspulse.WithUpgraderBufferSize(4096, 4096))
 	t.Cleanup(srv.Close)
+}
+
+// TestServer_ConnectFunc_RejectBody_NoLeak verifies the HTTP 401 response
+// body is a generic "unauthorized" string and does not leak the internal
+// error from ConnectFunc. This unit test runs in the default make check
+// gate (no integration tag required).
+func TestServer_ConnectFunc_RejectBody_NoLeak(t *testing.T) {
+	t.Parallel()
+	srv := wspulse.NewServer(func(r *http.Request) (string, string, error) {
+		return "", "", errors.New("internal: secret db details")
+	})
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(body)); got != "unauthorized" {
+		t.Errorf("response body = %q, want %q (internal error must not leak)", got, "unauthorized")
+	}
 }
 
 func TestMain(m *testing.M) {

--- a/server_test.go
+++ b/server_test.go
@@ -332,6 +332,32 @@ func TestWithOnTransportRestore_AcceptsNil(t *testing.T) {
 	t.Cleanup(srv.Close)
 }
 
+func TestWithUpgraderBufferSize_Zero_Panics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero readSize")
+		}
+	}()
+	wspulse.NewServer(acceptAll, wspulse.WithUpgraderBufferSize(0, 1024))
+}
+
+func TestWithUpgraderBufferSize_NegativeWriteSize_Panics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative writeSize")
+		}
+	}()
+	wspulse.NewServer(acceptAll, wspulse.WithUpgraderBufferSize(1024, -1))
+}
+
+func TestWithUpgraderBufferSize_ValidSizes_Accepted(t *testing.T) {
+	t.Parallel()
+	srv := wspulse.NewServer(acceptAll, wspulse.WithUpgraderBufferSize(4096, 4096))
+	t.Cleanup(srv.Close)
+}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/session.go
+++ b/session.go
@@ -1,7 +1,7 @@
 package wspulse
 
 import (
-	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -400,10 +400,12 @@ func (s *session) readPump(transport *websocket.Conn, h *hub) {
 	defer func() {
 		// Recover from panics in OnMessage handlers.
 		if r := recover(); r != nil {
-			readErr = fmt.Errorf("wspulse: readPump panic: %v", r)
+			stack := debug.Stack()
+			readErr = &PanicError{Value: r, Stack: stack}
 			s.config.logger.Error("wspulse: readPump panic recovered",
 				zap.String("conn_id", s.id),
 				zap.Any("panic", r),
+				zap.ByteString("stack", stack),
 			)
 		}
 


### PR DESCRIPTION
## Summary

- **PanicError type** — typed error with stack trace for `OnMessage` panic recovery, matchable via `errors.As` in `OnDisconnect`
- **Fix ConnectFunc error leak** — HTTP 401 response no longer exposes internal error details to clients
- **Broadcast optimization** — reusable scratch slice eliminates per-broadcast allocation
- **WithUpgraderBufferSize option** — configurable WebSocket upgrader I/O buffer sizes
- **Benchmarks** — 7 benchmarks covering ring buffer, broadcast fan-out, Send throughput, and drop-oldest backpressure
- **Documentation** — room pinning on resume clarified in ConnectFunc GoDoc and internals.md

## Test plan

- [x] `make check` (fmt + lint + unit tests with race detector)
- [x] `make check` with `INCLUDE_INTEGRATION=1` (all 117 tests pass)
- [x] All 7 benchmarks produce meaningful output
- [x] `errors.As` correctly matches `PanicError` in new test
- [x] ConnectFunc rejection returns generic "unauthorized" body
- [x] `WithUpgraderBufferSize` panics on invalid input, accepts valid sizes
- [x] Zero regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)