### PR TITLE
feat: resume intent detection with HTTP 410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Resume intent detection: clients reconnecting with `?resume=true` query parameter are rejected with HTTP 410 Gone when the session has expired, and `ResumeAttempt(roomID, connectionID, false)` is emitted
+- `CloseSessionExpired` (4100) re-exported from core — WebSocket close code for the hub race case where the session expires between HTTP pre-check and hub processing
+- `registerMessage.resumeIntent` internal field — carries resume intent from ServeHTTP to the hub
+
+### Changed
+
+- `ResumeAttempt` metric now fires with `success=false` for failed resume attempts (previously only fired with `success=true` on successful resume)
+- `ResumeAttempt` is now called from the ServeHTTP goroutine (failed pre-check) in addition to the hub goroutine
+
 ## [0.5.0] - 2026-03-25
 
 ### Added

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -234,6 +234,70 @@ effective window = pongWait + resumeWindow
 The client's exponential backoff reconnect (1 s, 2 s, 4 s, 8 s, ...) can
 attempt multiple retries within this window.
 
+### Resume Intent (Failed Resume Detection)
+
+When a client reconnects, it may include `?resume=true` in the URL to signal
+that it intends to resume an existing suspended session. This allows the
+server to distinguish between "new connection" and "reconnect attempt" and
+to detect failed resume attempts for metrics.
+
+#### ServeHTTP Pre-check
+
+```
+ConnectFunc(r) -> (roomID, connectionID)
+
+if ?resume=true:
+    if hub.get(connectionID) != nil:
+        -> proceed with upgrade + registerMessage (hub handles resume)
+    else:
+        -> ResumeAttempt(roomID, connectionID, false)
+        -> HTTP 410 Gone (no upgrade, no session created)
+        -> return
+else:
+    -> proceed with upgrade + registerMessage (normal new connection)
+```
+
+The pre-check uses `hub.get(connectionID)` which is a concurrent-safe
+`RLock` read -- the same pattern used by `Server.Send()` from external
+goroutines. This is a read, not a mutation, so it does not violate hub
+serialization.
+
+Rejecting at the HTTP layer (before WebSocket upgrade) avoids:
+1. An unnecessary upgrade handshake and teardown.
+2. Managing a WebSocket connection that will be immediately closed.
+3. Ambiguity about whether the connection is new or a failed resume.
+
+#### Hub Race Case (handleRegister)
+
+A race window exists between the HTTP pre-check and hub processing:
+
+```
+t0: ServeHTTP pre-check: hub.get(connID) != nil -> proceed
+t1: grace timer fires -> hub removes session
+t2: hub processes registerMessage -> session no longer exists
+```
+
+This window is small (upgrade handshake + channel send + hub iteration,
+typically a few milliseconds) but must be handled correctly.
+
+When `registerMessage.resumeIntent` is true but the session no longer
+exists in the hub:
+
+```
+handleRegister(message):
+    existing = connectionsByID[message.connectionID]
+    if !existing && message.resumeIntent:
+        -> ResumeAttempt(roomID, connectionID, false)
+        -> send WS close frame (code 4100 CloseSessionExpired)
+        -> close transport
+        -> return (no session created)
+```
+
+The behavior is consistent with the HTTP 410 rejection: resume was
+requested but the session is gone, so the answer is no. The close code
+4100 (`CloseSessionExpired`) conveys the same semantics as HTTP 410 but
+within the WebSocket protocol layer.
+
 ### Kick Bypass
 
 `Server.Kick(connectionID)` always destroys the session immediately, bypassing
@@ -297,7 +361,7 @@ must be safe for concurrent use.
 | `RoomDestroyed`         | hub goroutine       |
 | `ConnectionOpened`      | hub goroutine       |
 | `ConnectionClosed`      | hub goroutine       |
-| `ResumeAttempt`         | hub goroutine       |
+| `ResumeAttempt`         | hub goroutine (success=true, race case false), ServeHTTP goroutine (pre-check false) |
 | `MessageBroadcast`      | hub goroutine       |
 | `MessageReceived`       | readPump goroutine  |
 | `PongTimeout`           | readPump goroutine  |

--- a/hub.go
+++ b/hub.go
@@ -18,6 +18,7 @@ type registerMessage struct {
 	connectionID string
 	roomID       string
 	transport    *websocket.Conn
+	resumeIntent bool // true when the client connected with ?resume=true
 }
 
 // transportDiedMessage is sent by readPump when its WebSocket read loop exits.
@@ -165,6 +166,25 @@ func (h *hub) handleRegister(message registerMessage) {
 			)
 			h.disconnectSession(existing, nil, DisconnectNormal)
 		}
+	}
+
+	// Race case: the HTTP pre-check saw the session, but by the time the
+	// hub processes the registerMessage the grace timer has fired and
+	// destroyed it. The client wanted to resume but the session is gone.
+	// Reject with WS close 4100 (CloseSessionExpired) — do not create a
+	// new session, consistent with the HTTP 410 rejection in ServeHTTP.
+	if message.resumeIntent && !exists {
+		h.config.logger.Info("wspulse: resume rejected — session expired (race)",
+			zap.String("conn_id", message.connectionID),
+			zap.String("room_id", message.roomID),
+		)
+		h.config.metrics.ResumeAttempt(message.roomID, message.connectionID, false)
+		_ = message.transport.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(CloseSessionExpired, "session expired"),
+		)
+		_ = message.transport.Close()
+		return
 	}
 
 	// Create a new session.

--- a/metrics.go
+++ b/metrics.go
@@ -66,12 +66,17 @@ type MetricsCollector interface {
 	// was closed (see DisconnectReason constants).
 	ConnectionClosed(roomID, connectionID string, duration time.Duration, reason DisconnectReason)
 
-	// ResumeAttempt is called when a suspended session is successfully resumed
-	// by a reconnecting client. In the current implementation, success is
-	// always true: a failed resume (reconnect after grace expiry) results in
-	// a new session via ConnectionOpened rather than an identifiable
-	// failed-resume event. The success parameter is reserved for future use
-	// when failed resume detection is implemented.
+	// ResumeAttempt is called when a client attempts to resume a suspended session.
+	// success is true when the session was successfully resumed (transport swap),
+	// and false when the session no longer exists (grace window expired).
+	//
+	// A failed resume (success=false) is emitted in two scenarios:
+	//   - ServeHTTP pre-check: client connects with ?resume=true but
+	//     hub.get(connectionID) returns nil. HTTP 410 is returned.
+	//   - Hub race case: pre-check passed but the session expired between
+	//     the check and hub processing. WS close 4100 is sent.
+	//
+	// In both failure cases, no session is created and ConnectionOpened is not emitted.
 	ResumeAttempt(roomID, connectionID string, success bool)
 
 	// RoomCreated is called when the first connection joins a room,

--- a/metrics_integration_test.go
+++ b/metrics_integration_test.go
@@ -3,6 +3,7 @@
 package wspulse_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -541,5 +542,130 @@ func TestIntegration_MetricsCollector_Shutdown(t *testing.T) {
 	// Verify RoomDestroyed fired.
 	if n := rec.countByName("RoomDestroyed"); n != 1 {
 		t.Errorf("RoomDestroyed: want 1, got %d", n)
+	}
+}
+
+// TestIntegration_MetricsCollector_ResumeAttempt_Rejected verifies that when a
+// client reconnects with ?resume=true after the grace window has expired, the
+// server returns HTTP 410 Gone and emits ResumeAttempt(roomID, connectionID, false).
+// No ConnectionOpened should fire for the rejected reconnect attempt.
+func TestIntegration_MetricsCollector_ResumeAttempt_Rejected(t *testing.T) {
+	rec := &recordingCollector{}
+	connected := make(chan struct{}, 2)
+	disconnected := make(chan struct{}, 2)
+	dropped := make(chan struct{}, 2)
+	fc := newFakeClock()
+
+	srv := wspulse.NewServer(
+		func(r *http.Request) (string, string, error) {
+			return "resume-room", "resume-conn", nil
+		},
+		wspulse.WithMetrics(rec),
+		wspulse.WithResumeWindow(3*time.Minute),
+		wspulse.WithClock(fc),
+		wspulse.WithOnConnect(func(_ wspulse.Connection) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnTransportDrop(func(_ wspulse.Connection, _ error) {
+			select {
+			case dropped <- struct{}{}:
+			default:
+			}
+		}),
+		wspulse.WithOnDisconnect(func(_ wspulse.Connection, _ error) {
+			select {
+			case disconnected <- struct{}{}:
+			default:
+			}
+		}),
+	)
+	ts := httptest.NewServer(srv)
+	defer func() {
+		srv.Close()
+		ts.Close()
+	}()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+
+	// Step 1: Initial connection.
+	c1, resp1, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	if resp1 != nil && resp1.Body != nil {
+		resp1.Body.Close()
+	}
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for connect")
+	}
+
+	if n := rec.countByName("ConnectionOpened"); n != 1 {
+		t.Fatalf("ConnectionOpened after initial connect: want 1, got %d", n)
+	}
+
+	// Step 2: Drop transport → session suspends.
+	_ = c1.Close()
+	select {
+	case <-dropped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for transport drop")
+	}
+
+	// Step 3: Fire grace timer → session destroyed, onDisconnect fires.
+	fc.Fire(0)
+	select {
+	case <-disconnected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for disconnect after grace expiry")
+	}
+
+	// Step 4: Reconnect with ?resume=true → expect HTTP 410 Gone.
+	resumeURL := wsURL + "?resume=true"
+	c2, resp2, err := dialer.Dial(resumeURL, nil)
+	if c2 != nil {
+		c2.Close()
+	}
+
+	// The server should reject with HTTP 410 — the dial must fail.
+	if err == nil {
+		t.Fatal("expected Dial to fail with HTTP 410, but it succeeded")
+	}
+	if resp2 == nil {
+		t.Fatalf("expected HTTP response, got nil (err=%v)", err)
+	}
+	if resp2.Body != nil {
+		io.Copy(io.Discard, resp2.Body)
+		resp2.Body.Close()
+	}
+	if resp2.StatusCode != http.StatusGone {
+		t.Errorf("response status: want %d (Gone), got %d", http.StatusGone, resp2.StatusCode)
+	}
+
+	// Step 5: Verify ResumeAttempt(false) was emitted.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		events := rec.eventsByName("ResumeAttempt")
+		for _, e := range events {
+			if !e.success && e.roomID == "resume-room" && e.connectionID == "resume-conn" {
+				goto resumeFound
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ResumeAttempt(false) not emitted; events: %v", rec.snapshot())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+resumeFound:
+
+	// Step 6: Verify ConnectionOpened was NOT emitted for the rejected reconnect.
+	// Only the initial connection should have triggered ConnectionOpened.
+	if n := rec.countByName("ConnectionOpened"); n != 1 {
+		t.Errorf("ConnectionOpened: want 1 (initial only), got %d", n)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -97,6 +97,12 @@ func NewServer(connect ConnectFunc, options ...ServerOption) Server {
 
 // ServeHTTP upgrades the HTTP connection to WebSocket.
 // ConnectFunc is called to authenticate; a non-nil error yields HTTP 401.
+//
+// Resume intent pre-check: when the client connects with ?resume=true, the
+// server checks whether the session still exists before upgrading. If the
+// session has expired (grace window elapsed), the server responds with
+// HTTP 410 Gone and emits ResumeAttempt(roomID, connectionID, false).
+// This avoids an unnecessary WebSocket upgrade for a doomed connection.
 func (s *internalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Quick bail — hub is shutting down; don't upgrade or enqueue.
 	if s.hub.stopped.Load() {
@@ -117,6 +123,21 @@ func (s *internalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		connectionID = uuid.NewString()
 	}
 
+	resumeIntent := r.URL.Query().Get("resume") == "true"
+
+	// Resume intent pre-check: if the client wants to resume but the
+	// session no longer exists, reject at the HTTP layer (410 Gone).
+	// hub.get() uses RLock — same concurrent-safe read pattern as Send().
+	if resumeIntent && s.hub.get(connectionID) == nil {
+		s.config.logger.Info("wspulse: resume rejected — session expired",
+			zap.String("conn_id", connectionID),
+			zap.String("room_id", roomID),
+		)
+		s.config.metrics.ResumeAttempt(roomID, connectionID, false)
+		http.Error(w, "session expired", http.StatusGone)
+		return
+	}
+
 	transport, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		s.config.logger.Error("wspulse: upgrade failed", zap.Error(err))
@@ -127,6 +148,7 @@ func (s *internalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		connectionID: connectionID,
 		roomID:       roomID,
 		transport:    transport,
+		resumeIntent: resumeIntent,
 	}
 
 	s.config.logger.Debug("wspulse: connection upgraded",

--- a/types.go
+++ b/types.go
@@ -17,6 +17,10 @@ const (
 	BinaryMessage = core.BinaryMessage
 )
 
+// CloseSessionExpired is the WebSocket close code sent when a client requests
+// session resumption but the session no longer exists. See core.CloseSessionExpired.
+const CloseSessionExpired = core.CloseSessionExpired
+
 // Re-exported sentinel errors from github.com/wspulse/core.
 var (
 	ErrConnectionClosed = core.ErrConnectionClosed


### PR DESCRIPTION
## Summary

- Clients reconnecting with `?resume=true` after grace window expiry are rejected with HTTP 410 Gone (no WebSocket upgrade), and `ResumeAttempt(roomID, connectionID, false)` is emitted
- Hub race case (session expires between HTTP pre-check and hub processing) sends WS close 4100 (`CloseSessionExpired`) instead of creating a new session
- `CloseSessionExpired` (4100) re-exported from core; `ResumeAttempt` GoDoc updated to reflect `success=false` semantics

## Test plan

- [x] `TestIntegration_MetricsCollector_ResumeAttempt_Rejected` — connect, disconnect, grace expiry, reconnect with `?resume=true` → HTTP 410, ResumeAttempt(false) emitted, no ConnectionOpened
- [x] Existing `TestIntegration_MetricsCollector_ResumeAttempt` (success path) still passes
- [x] Full integration suite with race detector passes
- [ ] Hub race case test (to be added in follow-up — requires precise timing control between grace timer and hub processing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)