### PR TITLE
refactor: remove success bool from ResumeAttempt

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,16 +1,3 @@
 # TODOS
 
-## Failed resume detection: ResumeAttempt(..., false)
-
-When a client reconnects with a connectionID that has already expired (grace
-window elapsed), identify this as a "failed resume" and emit
-`ResumeAttempt(roomID, connectionID, false)` before creating the new session.
-
-The `success bool` parameter exists but is currently always `true`. Detecting
-failed resumes is non-trivial: after grace expiry the session is destroyed and
-the connectionID is freed. Distinguishing "new client reusing an ID" from
-"client that missed the resume window" may require protocol-level signaling
-(e.g. a client-sent `resume` intent header on the upgrade request).
-
-**Depends on:** MetricsCollector interface (this branch), possibly protocol
-changes in the `.github` repo.
+(none)

--- a/hub.go
+++ b/hub.go
@@ -142,7 +142,7 @@ func (h *hub) handleRegister(message registerMessage) {
 				onResume = func() { fn(existing) }
 			}
 			existing.attachWS(message.transport, h, onResume)
-			h.config.metrics.ResumeAttempt(existing.roomID, existing.id, true)
+			h.config.metrics.ResumeAttempt(existing.roomID, existing.id)
 			h.config.logger.Info("wspulse: session resumed",
 				zap.String("conn_id", message.connectionID),
 			)

--- a/metrics.go
+++ b/metrics.go
@@ -67,12 +67,10 @@ type MetricsCollector interface {
 	ConnectionClosed(roomID, connectionID string, duration time.Duration, reason DisconnectReason)
 
 	// ResumeAttempt is called when a suspended session is successfully resumed
-	// by a reconnecting client. In the current implementation, success is
-	// always true: a failed resume (reconnect after grace expiry) results in
-	// a new session via ConnectionOpened rather than an identifiable
-	// failed-resume event. The success parameter is reserved for future use
-	// when failed resume detection is implemented.
-	ResumeAttempt(roomID, connectionID string, success bool)
+	// by a reconnecting client. Only fires on successful resume — a reconnect
+	// after grace expiry creates a new session (ConnectionOpened) and is not
+	// tracked as a failed resume.
+	ResumeAttempt(roomID, connectionID string)
 
 	// RoomCreated is called when the first connection joins a room,
 	// causing the room to be allocated.
@@ -137,7 +135,7 @@ func (NoopCollector) ConnectionOpened(_, _ string) {}
 func (NoopCollector) ConnectionClosed(_, _ string, _ time.Duration, _ DisconnectReason) {}
 
 // ResumeAttempt is a no-op. See MetricsCollector.ResumeAttempt.
-func (NoopCollector) ResumeAttempt(_, _ string, _ bool) {}
+func (NoopCollector) ResumeAttempt(_, _ string) {}
 
 // RoomCreated is a no-op. See MetricsCollector.RoomCreated.
 func (NoopCollector) RoomCreated(_ string) {}

--- a/metrics_integration_test.go
+++ b/metrics_integration_test.go
@@ -296,10 +296,6 @@ func TestIntegration_MetricsCollector_ResumeAttempt(t *testing.T) {
 		t.Errorf("ConnectionOpened after resume: want 1, got %d", n)
 	}
 
-	events := rec.eventsByName("ResumeAttempt")
-	if len(events) > 0 && !events[0].success {
-		t.Errorf("ResumeAttempt success = false, want true")
-	}
 }
 
 func TestIntegration_MetricsCollector_FrameDropped_SendFull(t *testing.T) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -22,7 +22,7 @@ func TestNoopCollector_AllMethodsCallable(t *testing.T) {
 	var c wspulse.NoopCollector
 	c.ConnectionOpened("room", "conn")
 	c.ConnectionClosed("room", "conn", time.Second, wspulse.DisconnectNormal)
-	c.ResumeAttempt("room", "conn", true)
+	c.ResumeAttempt("room", "conn")
 	c.RoomCreated("room")
 	c.RoomDestroyed("room")
 	c.MessageReceived("room", 100)
@@ -81,7 +81,6 @@ type metricsEvent struct {
 	sizeBytes    int
 	fanOut       int
 	duration     time.Duration
-	success      bool
 	used         int
 	capacity     int
 	reason       wspulse.DisconnectReason
@@ -99,8 +98,8 @@ func (r *recordingCollector) ConnectionOpened(roomID, connectionID string) {
 func (r *recordingCollector) ConnectionClosed(roomID, connectionID string, duration time.Duration, reason wspulse.DisconnectReason) {
 	r.record(metricsEvent{name: "ConnectionClosed", roomID: roomID, connectionID: connectionID, duration: duration, reason: reason})
 }
-func (r *recordingCollector) ResumeAttempt(roomID, connectionID string, success bool) {
-	r.record(metricsEvent{name: "ResumeAttempt", roomID: roomID, connectionID: connectionID, success: success})
+func (r *recordingCollector) ResumeAttempt(roomID, connectionID string) {
+	r.record(metricsEvent{name: "ResumeAttempt", roomID: roomID, connectionID: connectionID})
 }
 func (r *recordingCollector) RoomCreated(roomID string) {
 	r.record(metricsEvent{name: "RoomCreated", roomID: roomID})


### PR DESCRIPTION
## Summary

- Remove unused `success bool` parameter from `MetricsCollector.ResumeAttempt` — resume success rate is derivable from existing metrics (`ResumeAttempt` count vs `ConnectionClosed(graceExpired)` count)
- Update hub call site, unit tests, and integration test assertions
- Clear resolved TODOS entry

## Test plan

- [x] `make check` passes (fmt, lint, unit tests with race detector)
- [x] `make test-integration` passes
- [x] Metrics adapters updated in parallel PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)