### PR TITLE
feat: remove Frame.ID field

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | ------------- | ----------------------------------------------------------------------- |
 | `Server`      | Manages sessions, heartbeats, and room routing                          |
 | `Connection`  | A logical WebSocket session (`ID`, `RoomID`, `Send`, `Close`, `Done`)   |
-| `Frame`       | Transport unit (`ID`, `Event`, `Payload []byte`) — re-exported from core |
+| `Frame`       | Transport unit (`Event`, `Payload []byte`) — re-exported from core       |
 | `ConnectFunc` | `func(*http.Request) (roomID, connectionID string, err error)`          |
 | `Codec`       | Interface: `Encode(Frame)`, `Decode([]byte)`, `FrameType()` — from core |
 | `JSONCodec`   | Default codec — text frames, JSON payload — re-exported from core       |

--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ The router from [wspulse/core](https://github.com/wspulse/core) integrates direc
 
 ```json
 {
-  "id": "msg-001",
   "event": "chat.message",
   "payload": { "text": "hello" }
 }


### PR DESCRIPTION
## Summary

Verify no Frame.ID usage after core removal. No code changes needed — server only uses Connection.ID(), not Frame.ID.

## Changes

- No code changes (verification only)

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] No unrelated code reformatting in this PR