### PR TITLE
feat: add NewTestServer test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `NewTestServer(t, connect, opts...) wsURL` — test helper for spinning up an in-process server with auto-cleanup
+- `NewTestServer(t, connect, opts...) string` — test helper for spinning up an in-process server with auto-cleanup; returns the `ws://...` URL string
 
 ---
 
@@ -110,7 +110,11 @@
 - `Server.Close` is synchronous — returns only after all goroutines exit
 - Data race in `attachWS` buffer length check
 
-[Unreleased]: https://github.com/wspulse/server/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/wspulse/server/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/wspulse/server/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/wspulse/server/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/wspulse/server/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/wspulse/server/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/wspulse/server/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/wspulse/server/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/wspulse/server/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `NewTestServer(t, connect, opts...) wsURL` — test helper for spinning up an in-process server with auto-cleanup
+
+---
+
 ## [0.6.0] - 2026-03-27
 
 ### Changed

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,21 @@
+package wspulse
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// NewTestServer creates an in-process test server for use in application tests.
+// It returns the WebSocket URL (ws://...) ready for client.Dial.
+// The server and its HTTP listener are automatically cleaned up when the test ends.
+func NewTestServer(t testing.TB, connect ConnectFunc, opts ...ServerOption) string {
+	t.Helper()
+	srv := NewServer(connect, opts...)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		srv.Close()
+		ts.Close()
+	})
+	return "ws" + strings.TrimPrefix(ts.URL, "http")
+}

--- a/testing_test.go
+++ b/testing_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorilla/websocket"
+
 	wspulse "github.com/wspulse/server"
 )
 
@@ -13,6 +15,12 @@ func TestNewTestServer_ReturnsWSURL(t *testing.T) {
 		return "room", "", nil
 	})
 	if !strings.HasPrefix(url, "ws://") {
-		t.Errorf("expected ws:// prefix, got %q", url)
+		t.Fatalf("expected ws:// prefix, got %q", url)
 	}
+
+	c, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("failed to dial %q: %v", url, err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
 }

--- a/testing_test.go
+++ b/testing_test.go
@@ -1,0 +1,18 @@
+package wspulse_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	wspulse "github.com/wspulse/server"
+)
+
+func TestNewTestServer_ReturnsWSURL(t *testing.T) {
+	url := wspulse.NewTestServer(t, func(r *http.Request) (string, string, error) {
+		return "room", "", nil
+	})
+	if !strings.HasPrefix(url, "ws://") {
+		t.Errorf("expected ws:// prefix, got %q", url)
+	}
+}


### PR DESCRIPTION
## Summary

Add `NewTestServer(t, connect, opts...) string` — a one-liner to spin up an in-process test server with auto-cleanup via `t.Cleanup`. Returns a `ws://` URL ready for `client.Dial`.

Closes wspulse/.github#16

## Changes

- New `testing.go`: `NewTestServer` function that wraps `NewServer` + `httptest.NewServer` with automatic cleanup
- New `testing_test.go`: unit test verifying the returned URL has a `ws://` prefix
- `CHANGELOG.md`: added entry under `[Unreleased]`

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional (list only those that apply)

- [x] New public API: includes GoDoc comments

---
Closes wspulse/.github#16