### PR TITLE
feat: add WithMaxConnections server option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `WithMaxConnections(n int)` option — server-wide connection cap. Default 0 (no limit). Exceeding the limit rejects new connections with HTTP 503.
+
+---
+
 ## [0.6.0] - 2026-03-27
 
 ### Changed

--- a/hub.go
+++ b/hub.go
@@ -69,10 +69,11 @@ type hub struct {
 	kick          chan kickRequest
 	done          chan struct{} // closed by Server.Close()
 
-	mu      sync.RWMutex
-	stopped atomic.Bool // set by shutdown(); ServeHTTP checks this early
-	scratch []*session  // reusable slice for broadcast snapshot; avoids per-broadcast allocation
-	config  *serverConfig
+	mu                sync.RWMutex
+	stopped           atomic.Bool  // set by shutdown(); ServeHTTP checks this early
+	activeConnections atomic.Int64 // logical session count; written by hub goroutine, read by ServeHTTP
+	scratch           []*session   // reusable slice for broadcast snapshot; avoids per-broadcast allocation
+	config            *serverConfig
 }
 
 func newHub(config *serverConfig) *hub {
@@ -194,6 +195,7 @@ func (h *hub) handleRegister(message registerMessage) {
 		h.config.metrics.RoomCreated(message.roomID)
 	}
 
+	h.activeConnections.Add(1)
 	newSession.attachWS(message.transport, h, nil)
 	h.config.metrics.ConnectionOpened(message.roomID, message.connectionID)
 
@@ -437,6 +439,7 @@ func (h *hub) handleBroadcast(message broadcastMessage) {
 // (closeOnce makes it idempotent).
 func (h *hub) disconnectSession(target *session, err error, reason DisconnectReason) {
 	h.removeSession(target)
+	h.activeConnections.Add(-1)
 	h.config.metrics.ConnectionClosed(target.roomID, target.id, time.Since(target.connectedAt), reason)
 	_ = target.Close()
 	if fn := h.config.onDisconnect; fn != nil {

--- a/options.go
+++ b/options.go
@@ -53,6 +53,7 @@ type serverConfig struct {
 	upgraderReadBufferSize  int
 	upgraderWriteBufferSize int
 	metrics                 MetricsCollector
+	maxConnections          int
 }
 
 func defaultConfig(connect ConnectFunc) *serverConfig {
@@ -261,4 +262,15 @@ func WithMetrics(collector MetricsCollector) ServerOption {
 		panic("wspulse: WithMetrics: collector must not be nil")
 	}
 	return func(c *serverConfig) { c.metrics = collector }
+}
+
+// WithMaxConnections sets a server-wide connection cap. When the number of
+// active connections reaches n, new connections are rejected with HTTP 503
+// before the WebSocket upgrade. Default is 0 (no limit).
+// Panics if n is negative.
+func WithMaxConnections(n int) ServerOption {
+	if n < 0 {
+		panic("wspulse: WithMaxConnections: n must not be negative")
+	}
+	return func(c *serverConfig) { c.maxConnections = n }
 }

--- a/options.go
+++ b/options.go
@@ -265,9 +265,10 @@ func WithMetrics(collector MetricsCollector) ServerOption {
 }
 
 // WithMaxConnections sets a server-wide connection cap. When the number of
-// active connections reaches n, new connections are rejected with HTTP 503
-// before the WebSocket upgrade. Default is 0 (no limit).
-// Panics if n is negative.
+// tracked sessions reaches n, new connections are rejected with HTTP 503
+// before the WebSocket upgrade. If session resumption is enabled, suspended
+// sessions within the resume window still count toward this cap until they are
+// destroyed. Default is 0 (no limit). Panics if n is negative.
 func WithMaxConnections(n int) ServerOption {
 	if n < 0 {
 		panic("wspulse: WithMaxConnections: n must not be negative")

--- a/server.go
+++ b/server.go
@@ -105,6 +105,15 @@ func (s *internalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject if server-wide connection cap is reached.
+	if max := s.config.maxConnections; max > 0 && s.hub.activeConnections.Load() >= int64(max) {
+		s.config.logger.Warn("wspulse: ServeHTTP rejected — max connections reached",
+			zap.Int("max_connections", max),
+		)
+		http.Error(w, "too many connections", http.StatusServiceUnavailable)
+		return
+	}
+
 	roomID, connectionID, err := s.config.connect(r)
 	if err != nil {
 		s.config.logger.Debug("wspulse: connect rejected",

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -4055,7 +4055,10 @@ func TestWithMaxConnections_RejectsOverLimit(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected second Dial to fail, but it succeeded")
 	}
-	if resp != nil && resp.StatusCode != http.StatusServiceUnavailable {
+	if resp == nil {
+		t.Fatalf("expected HTTP %d response, got nil (err=%v)", http.StatusServiceUnavailable, err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("want 503, got %d", resp.StatusCode)
 	}
 }
@@ -4085,6 +4088,7 @@ func TestWithMaxConnections_AllowsAfterDisconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first Dial failed: %v", err)
 	}
+	t.Cleanup(func() { _ = c1.Close() })
 
 	// Wait for hub to register.
 	select {

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -3732,3 +3732,134 @@ func TestOnTransportRestore_NotFiredOnClosedSession(t *testing.T) {
 		// OK — callback did not fire for the closed session.
 	}
 }
+
+// ── WithMaxConnections integration tests ─────────────────────────────────────
+
+// uniqueIDConnect returns a ConnectFunc that assigns a unique connectionID to
+// each connection using an atomic counter. All connections join the same room.
+func uniqueIDConnect() wspulse.ConnectFunc {
+	var counter atomic.Int64
+	return func(r *http.Request) (string, string, error) {
+		id := fmt.Sprintf("conn-%d", counter.Add(1))
+		return "test-room", id, nil
+	}
+}
+
+func TestWithMaxConnections_Zero_NoLimit(t *testing.T) {
+	t.Parallel()
+	srv := wspulse.NewServer(uniqueIDConnect(),
+		wspulse.WithMaxConnections(0),
+	)
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+
+	// Connect 5 clients — all should succeed with no limit.
+	for i := 0; i < 5; i++ {
+		c, _, err := dialer.Dial(u, nil)
+		if err != nil {
+			t.Fatalf("Dial %d failed: %v", i, err)
+		}
+		t.Cleanup(func() { _ = c.Close() })
+	}
+}
+
+func TestWithMaxConnections_RejectsOverLimit(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 2)
+	srv := wspulse.NewServer(uniqueIDConnect(),
+		wspulse.WithMaxConnections(1),
+		wspulse.WithOnConnect(func(wspulse.Connection) {
+			connected <- struct{}{}
+		}),
+	)
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+
+	// First connection should succeed.
+	c1, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("first Dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = c1.Close() })
+
+	// Wait for hub to register the connection.
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for first connection to register")
+	}
+
+	// Second connection should be rejected with HTTP 503.
+	_, resp, err := dialer.Dial(u, nil)
+	if err == nil {
+		t.Fatal("expected second Dial to fail, but it succeeded")
+	}
+	if resp != nil && resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestWithMaxConnections_AllowsAfterDisconnect(t *testing.T) {
+	t.Parallel()
+	connected := make(chan wspulse.Connection, 2)
+	disconnected := make(chan struct{}, 2)
+	srv := wspulse.NewServer(uniqueIDConnect(),
+		wspulse.WithMaxConnections(1),
+		wspulse.WithOnConnect(func(c wspulse.Connection) {
+			connected <- c
+		}),
+		wspulse.WithOnDisconnect(func(wspulse.Connection, error) {
+			disconnected <- struct{}{}
+		}),
+	)
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	u := "ws" + strings.TrimPrefix(ts.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+
+	// Connect at limit.
+	c1, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("first Dial failed: %v", err)
+	}
+
+	// Wait for hub to register.
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for first connection to register")
+	}
+
+	// Disconnect to free the slot.
+	_ = c1.Close()
+
+	// Wait for hub to process the disconnect.
+	select {
+	case <-disconnected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for disconnect")
+	}
+
+	// New connection should now succeed.
+	c2, _, err := dialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("second Dial failed after disconnect: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Close() })
+
+	select {
+	case <-connected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for second connection to register")
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -391,6 +391,30 @@ func TestServer_ConnectFunc_RejectBody_NoLeak(t *testing.T) {
 	}
 }
 
+// ── WithMaxConnections option tests ────────────────────────────────────────────
+
+func TestWithMaxConnections_NegativePanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for negative max connections")
+		}
+	}()
+	_ = wspulse.WithMaxConnections(-1)
+}
+
+func TestWithMaxConnections_ZeroAccepted(t *testing.T) {
+	t.Parallel()
+	srv := wspulse.NewServer(acceptAll, wspulse.WithMaxConnections(0))
+	t.Cleanup(srv.Close)
+}
+
+func TestWithMaxConnections_PositiveAccepted(t *testing.T) {
+	t.Parallel()
+	srv := wspulse.NewServer(acceptAll, wspulse.WithMaxConnections(10))
+	t.Cleanup(srv.Close)
+}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }


### PR DESCRIPTION
## Summary

Add a server-wide connection cap via `WithMaxConnections(n int)`. When the limit is reached, new connections are rejected with HTTP 503 before the WebSocket upgrade. Default is 0 (no limit).

Closes wspulse/.github#12

## Changes

- Added `maxConnections int` field to `serverConfig` (default 0 = no limit)
- Added `WithMaxConnections(n int) ServerOption` — panics if n < 0 (setup-time programmer error per panic policy)
- Added `activeConnections atomic.Int64` on `hub` — incremented in `handleRegister` (new session only, not resume), decremented in `disconnectSession`
- Added check in `ServeHTTP` before `ConnectFunc`: if `maxConnections > 0 && activeConnections >= maxConnections` → HTTP 503
- Added unit tests: negative panics, zero accepted, positive accepted
- Added integration tests: zero means no limit, rejects over limit (503), allows after disconnect
- Updated CHANGELOG [Unreleased]

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional (list only those that apply)

- [x] New public API: includes GoDoc comments
- [x] Hub serialization not violated (no session state mutation outside hub goroutine)

---
Closes wspulse/.github#12