### PR TITLE
feat: add WithMaxConnections server option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `NewTestServer(t, connect, opts...) string` — test helper for spinning up an in-process server with auto-cleanup; returns the `ws://...` URL string
+- `WithMaxConnections(n int)` — cap concurrent connections; new connections are rejected with HTTP 503 when the limit is reached. Suspended sessions (within resume window) do not count toward the limit
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | `WithCodec(c)`              | JSONCodec                            |
 | `WithCheckOrigin(fn)`       | allow all                            |
 | `WithLogger(l)`             | zap.NewNop() — accepts `*zap.Logger` |
+| `WithMaxConnections(n)`     | 0 (unlimited)                        |
 | `WithMetrics(mc)`           | NoopCollector — accepts `MetricsCollector` |
 
 ---

--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,11 @@ var (
 	// ErrServerClosed is returned by Server.Broadcast (and potentially
 	// other methods) when the Server has already been shut down via Close().
 	ErrServerClosed = errors.New("wspulse: server is closed")
+
+	// ErrConnectionLimitReached is returned when the server has reached
+	// the maximum number of concurrent connections configured via
+	// WithMaxConnections. The HTTP response is 503 Service Unavailable.
+	ErrConnectionLimitReached = errors.New("wspulse: connection limit reached")
 )
 
 // PanicError wraps a panic recovered from an OnMessage callback.

--- a/export_test.go
+++ b/export_test.go
@@ -14,6 +14,12 @@ func WithClock(c Clock) ServerOption {
 	return func(cfg *serverConfig) { cfg.clock = c }
 }
 
+// ActiveConnections returns the current value of the activeConnections counter.
+// Test-only — used to verify counter correctness in component tests.
+func ActiveConnections(srv Server) int64 {
+	return srv.(*internalServer).hub.activeConnections.Load()
+}
+
 // InjectTransport bypasses ServeHTTP and pushes a registerMessage directly
 // into the hub's register channel. Test-only — allows component tests to
 // inject mock transports without HTTP upgrade.

--- a/hub.go
+++ b/hub.go
@@ -70,6 +70,14 @@ type hub struct {
 	kick          chan kickRequest
 	done          chan struct{} // closed by Server.Close()
 
+	// activeConnections tracks the number of sessions with an active WebSocket
+	// transport. Suspended sessions (within resume window, awaiting reconnect)
+	// are excluded. This counter is used by ServeHTTP to enforce maxConnections
+	// as a resource-protection cap (goroutine pairs, file descriptors, send buffers).
+	//
+	// Written exclusively by the hub goroutine. Read atomically by ServeHTTP.
+	activeConnections atomic.Int64
+
 	mu      sync.RWMutex
 	stopped atomic.Bool // set by shutdown(); ServeHTTP checks this early
 	scratch []*session  // reusable slice for broadcast snapshot; avoids per-broadcast allocation
@@ -137,6 +145,8 @@ func (h *hub) handleRegister(message registerMessage) {
 			// already enqueued (timer fired before Stop) is detected
 			// as stale and ignored by handleGraceExpired.
 			existing.cancelGraceTimer()
+			existing.suspended = false
+			h.activeConnections.Add(1)
 
 			var onResume func()
 			if fn := h.config.onTransportRestore; fn != nil {
@@ -195,6 +205,7 @@ func (h *hub) handleRegister(message registerMessage) {
 		h.config.metrics.RoomCreated(message.roomID)
 	}
 
+	h.activeConnections.Add(1)
 	newSession.attachWS(message.transport, h, nil)
 	h.config.metrics.ConnectionOpened(message.roomID, message.connectionID)
 
@@ -276,6 +287,8 @@ func (h *hub) handleTransportDied(message transportDiedMessage) {
 			)
 			return
 		}
+		target.suspended = true
+		h.activeConnections.Add(-1)
 		timer := h.config.clock.AfterFunc(h.config.resumeWindow, func() {
 			select {
 			case h.graceExpired <- graceExpiredMessage{session: target, epoch: epoch}:
@@ -437,6 +450,9 @@ func (h *hub) handleBroadcast(message broadcastMessage) {
 // onDisconnect. Safe to call even if Close() was already called externally
 // (closeOnce makes it idempotent).
 func (h *hub) disconnectSession(target *session, err error, reason DisconnectReason) {
+	if !target.suspended {
+		h.activeConnections.Add(-1)
+	}
 	h.removeSession(target)
 	h.config.metrics.ConnectionClosed(target.roomID, target.id, time.Since(target.connectedAt), reason)
 	_ = target.Close()

--- a/max_connections_test.go
+++ b/max_connections_test.go
@@ -1,0 +1,177 @@
+package wspulse_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wspulse "github.com/wspulse/server"
+)
+
+// ── WithMaxConnections option validation ────────────────────────────────────
+
+func TestWithMaxConnections_NegativePanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { wspulse.WithMaxConnections(-1) })
+}
+
+func TestWithMaxConnections_ZeroAccepted(t *testing.T) {
+	t.Parallel()
+	assert.NotPanics(t, func() { wspulse.WithMaxConnections(0) })
+}
+
+func TestWithMaxConnections_PositiveAccepted(t *testing.T) {
+	t.Parallel()
+	assert.NotPanics(t, func() { wspulse.WithMaxConnections(100) })
+}
+
+// ── Zero means unlimited ────────────────────────────────────────────────────
+
+func TestMaxConnections_ZeroMeansUnlimited(t *testing.T) {
+	t.Parallel()
+	const n = 5
+	connected := make(chan struct{}, n)
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithMaxConnections(0),
+		wspulse.WithOnConnect(func(_ wspulse.Connection) { connected <- struct{}{} }),
+	)
+	t.Cleanup(srv.Close)
+
+	for i := 0; i < n; i++ {
+		injectAndWait(t, srv, fmt.Sprintf("conn-%d", i), "room", connected)
+	}
+	assert.Equal(t, int64(n), wspulse.ActiveConnections(srv))
+}
+
+// ── Rejects over limit ──────────────────────────────────────────────────────
+
+func TestMaxConnections_RejectsOverLimit(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 1)
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithMaxConnections(1),
+		wspulse.WithOnConnect(func(_ wspulse.Connection) { connected <- struct{}{} }),
+	)
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// Fill the single slot via InjectTransport.
+	injectAndWait(t, srv, "conn-1", "room", connected)
+	require.Equal(t, int64(1), wspulse.ActiveConnections(srv))
+
+	// Second connection via HTTP — expect 503.
+	resp, err := http.Get(ts.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// ── Allows after disconnect ─────────────────────────────────────────────────
+
+func TestMaxConnections_AllowsAfterDisconnect(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 2)
+	disconnected := make(chan struct{}, 1)
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithMaxConnections(1),
+		wspulse.WithOnConnect(func(_ wspulse.Connection) { connected <- struct{}{} }),
+		wspulse.WithOnDisconnect(func(_ wspulse.Connection, _ error) { disconnected <- struct{}{} }),
+	)
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	mt := injectAndWait(t, srv, "conn-1", "room", connected)
+	require.Equal(t, int64(1), wspulse.ActiveConnections(srv))
+
+	// Disconnect.
+	mt.InjectError(errors.New("connection closed"))
+	select {
+	case <-disconnected:
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for OnDisconnect")
+	}
+	require.Equal(t, int64(0), wspulse.ActiveConnections(srv))
+
+	// New HTTP request — should NOT get 503.
+	resp, err := http.Get(ts.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.NotEqual(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// ── Resume bypasses cap ─────────────────────────────────────────────────────
+
+func TestMaxConnections_ResumeBypassesCap(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 2)
+	dropped := make(chan struct{}, 1)
+	restored := make(chan struct{}, 1)
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithMaxConnections(1),
+		wspulse.WithResumeWindow(5*time.Second),
+		wspulse.WithOnConnect(func(_ wspulse.Connection) { connected <- struct{}{} }),
+		wspulse.WithOnTransportDrop(func(_ wspulse.Connection, _ error) { dropped <- struct{}{} }),
+		wspulse.WithOnTransportRestore(func(_ wspulse.Connection) { restored <- struct{}{} }),
+	)
+	t.Cleanup(srv.Close)
+
+	// Connect and drop → suspended (counter decremented to 0).
+	connectAndDrop(t, srv, "conn-1", "room", connected, dropped)
+	require.Equal(t, int64(0), wspulse.ActiveConnections(srv))
+
+	// Resume with same connectionID → counter back to 1.
+	reconnect(t, srv, "conn-1", "room", restored)
+	assert.Equal(t, int64(1), wspulse.ActiveConnections(srv))
+}
+
+// ── Grace expired frees slot ────────────────────────────────────────────────
+
+func TestMaxConnections_GraceExpiredFreesSlot(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 2)
+	dropped := make(chan struct{}, 1)
+	disconnected := make(chan struct{}, 1)
+	fc := newFakeClock()
+	srv := wspulse.NewServer(
+		acceptAll,
+		wspulse.WithMaxConnections(1),
+		wspulse.WithResumeWindow(30*time.Second),
+		wspulse.WithClock(fc),
+		wspulse.WithOnConnect(func(_ wspulse.Connection) { connected <- struct{}{} }),
+		wspulse.WithOnTransportDrop(func(_ wspulse.Connection, _ error) { dropped <- struct{}{} }),
+		wspulse.WithOnDisconnect(func(_ wspulse.Connection, _ error) { disconnected <- struct{}{} }),
+	)
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// Connect and drop → suspended.
+	connectAndDrop(t, srv, "conn-1", "room", connected, dropped)
+	require.Equal(t, int64(0), wspulse.ActiveConnections(srv))
+
+	// Fire the grace timer → session destroyed.
+	fc.Fire(0)
+	select {
+	case <-disconnected:
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for OnDisconnect after grace expiry")
+	}
+
+	// New HTTP request — slot is free, should NOT get 503.
+	resp, err := http.Get(ts.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.NotEqual(t, http.StatusServiceUnavailable, resp.StatusCode)
+}

--- a/options.go
+++ b/options.go
@@ -52,6 +52,7 @@ type serverConfig struct {
 	clock                   clock
 	upgraderReadBufferSize  int
 	upgraderWriteBufferSize int
+	maxConnections          int // 0 = unlimited
 	metrics                 MetricsCollector
 }
 
@@ -251,6 +252,17 @@ func WithUpgraderBufferSize(readSize, writeSize int) ServerOption {
 		c.upgraderReadBufferSize = readSize
 		c.upgraderWriteBufferSize = writeSize
 	}
+}
+
+// WithMaxConnections sets the maximum number of concurrent connections.
+// When the limit is reached, new connections are rejected with HTTP 503
+// before the WebSocket upgrade. Zero means unlimited (the default).
+// Panics if n is negative.
+func WithMaxConnections(n int) ServerOption {
+	if n < 0 {
+		panic("wspulse: WithMaxConnections: n must be >= 0")
+	}
+	return func(c *serverConfig) { c.maxConnections = n }
 }
 
 // WithMetrics configures the MetricsCollector used by the Server.

--- a/server.go
+++ b/server.go
@@ -105,6 +105,15 @@ func (s *internalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Connection cap — reject before calling ConnectFunc or upgrading.
+	if max := s.config.maxConnections; max > 0 && s.hub.activeConnections.Load() >= int64(max) {
+		s.config.logger.Warn("wspulse: connection limit reached",
+			zap.Int("max_connections", max),
+		)
+		http.Error(w, "connection limit reached", http.StatusServiceUnavailable)
+		return
+	}
+
 	roomID, connectionID, err := s.config.connect(r)
 	if err != nil {
 		s.config.logger.Debug("wspulse: connect rejected",

--- a/session.go
+++ b/session.go
@@ -79,6 +79,11 @@ type session struct {
 
 	connectedAt time.Time // session creation time; written once, read-only thereafter
 
+	// suspended is true when the session's activeConnections counter has been
+	// decremented on transport detach. Prevents double-decrement in disconnectSession.
+	// Written only by the hub goroutine.
+	suspended bool
+
 	closeOnce sync.Once
 	config    *serverConfig
 }


### PR DESCRIPTION
## Summary

Add `WithMaxConnections(n int)` server option that enforces a server-wide concurrent connection cap. When the limit is reached, new connections are rejected with HTTP 503 before the WebSocket upgrade. Closes wspulse/.github#12. Replaces #16.

## Changes

- Add `maxConnections int` field to `serverConfig` (default 0 = unlimited)
- Add `WithMaxConnections(n int) ServerOption` — panics if n < 0 (setup-time programmer error)
- Add `ErrConnectionLimitReached` sentinel error
- Add `activeConnections atomic.Int64` counter on `hub` — tracks sessions with active transport only; suspended sessions are excluded
- Add `suspended bool` field on `session` to prevent double-decrement in `disconnectSession`
- Add cap check in `ServeHTTP` before `ConnectFunc` — returns HTTP 503 when at capacity
- Counter state transitions: new session (++), suspend (--), resume (++), destroy (-- only if not suspended)
- 9 component tests covering: option validation, unlimited default, rejection at cap, slot release on disconnect, resume bypasses cap, grace expiry frees slot
- CHANGELOG and README entries

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] New public API: includes GoDoc comments
- [x] Hub serialization not violated (no session state mutation outside hub goroutine)