### PR TITLE
fix: preserve disconnect error in race paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix race between `Close()` and `handleTransportDied` where `Close()` sets `stateClosed` before `detachWS()` runs, causing `onDisconnect` to never fire. The hub now calls `disconnectSession` when `detachWS` detects a concurrently-closed session.
-- Fix `ResumeAttempt` metric firing after `attachWS` goroutine spawn, creating a window where the recording is not visible to the test's synchronous assertion. Moved metric call before `attachWS`.
-
 ---
 
 ## [0.7.0] - 2026-04-04
@@ -20,6 +15,11 @@
 - Extracted `Transport` interface for WebSocket connection abstraction (enables mock-based testing via `InjectTransport`)
 - Migrated all tests to deterministic component tests using mock transport — zero network I/O, zero flakes
 - Adopted `testify` for test assertions
+
+### Fixed
+
+- Fix race between `Close()` and `handleTransportDied` where `Close()` sets `stateClosed` before `detachWS()` runs, causing `OnDisconnect` to never fire. The hub now calls `disconnectSession` when `detachWS` detects a concurrently-closed session.
+- Fix `ResumeAttempt` metric firing after `attachWS` goroutine spawn, creating a window where the recording is not visible to the test's synchronous assertion. Moved metric call before `attachWS`.
 
 ---
 

--- a/hub.go
+++ b/hub.go
@@ -294,6 +294,10 @@ func (h *hub) handleTransportDied(message transportDiedMessage) {
 			h.config.logger.Info("wspulse: suspended session closed by application (race path)",
 				zap.String("conn_id", target.id),
 			)
+			// Pass message.err (not nil): OnTransportDrop was never called
+			// because detachWS succeeded but Close() raced in before the
+			// timer was assigned. The transport error must reach OnDisconnect
+			// so it is delivered exactly once across the two callbacks.
 			h.disconnectSession(target, message.err, DisconnectNormal)
 			return
 		}

--- a/hub.go
+++ b/hub.go
@@ -275,7 +275,7 @@ func (h *hub) handleTransportDied(message transportDiedMessage) {
 			h.config.logger.Debug("wspulse: detachWS returned not-ok (session closed concurrently)",
 				zap.String("conn_id", target.id),
 			)
-			h.disconnectSession(target, nil, DisconnectNormal)
+			h.disconnectSession(target, message.err, DisconnectNormal)
 			return
 		}
 		timer := h.config.clock.AfterFunc(h.config.resumeWindow, func() {
@@ -294,7 +294,7 @@ func (h *hub) handleTransportDied(message transportDiedMessage) {
 			h.config.logger.Info("wspulse: suspended session closed by application (race path)",
 				zap.String("conn_id", target.id),
 			)
-			h.disconnectSession(target, nil, DisconnectNormal)
+			h.disconnectSession(target, message.err, DisconnectNormal)
 			return
 		}
 		target.graceTimer = timer

--- a/session.go
+++ b/session.go
@@ -460,17 +460,13 @@ func (s *session) readPump(transport core.Transport, h *hub) {
 			if errors.As(err, &ne) && ne.Timeout() {
 				s.config.metrics.PongTimeout(s.roomID, s.id)
 			}
-			if websocket.IsUnexpectedCloseError(err,
-				websocket.CloseGoingAway,
-				websocket.CloseNormalClosure,
-				websocket.CloseAbnormalClosure,
-			) {
-				readErr = err
-				s.config.logger.Warn("wspulse: unexpected close", zap.String("conn_id", s.id), zap.Error(err))
-			} else {
+			if isNormalClose(err) {
 				s.config.logger.Debug("wspulse: connection closed normally",
 					zap.String("conn_id", s.id),
 				)
+			} else {
+				readErr = err
+				s.config.logger.Warn("wspulse: unexpected close", zap.String("conn_id", s.id), zap.Error(err))
 			}
 			return
 		}
@@ -484,6 +480,32 @@ func (s *session) readPump(transport core.Transport, h *hub) {
 			fn(s, frame)
 		}
 	}
+}
+
+// isNormalClose reports whether err represents an expected, orderly
+// connection close. When true, OnDisconnect receives a nil error.
+//
+// Normal close conditions:
+//   - net.ErrClosed: local Close(), Kick(), or Server.Close() closed
+//     the transport via writePump defer.
+//   - *websocket.CloseError with code 1000 (CloseNormalClosure):
+//     remote sent a standard close frame.
+//   - *websocket.CloseError with code 1001 (CloseGoingAway):
+//     remote is shutting down (e.g. browser tab closed).
+//
+// Everything else is abnormal and propagated to OnDisconnect as a
+// non-nil error: network resets, I/O timeouts, CloseAbnormalClosure
+// (1006), protocol errors, and any other read failure.
+func isNormalClose(err error) bool {
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var ce *websocket.CloseError
+	if errors.As(err, &ce) {
+		return ce.Code == websocket.CloseNormalClosure ||
+			ce.Code == websocket.CloseGoingAway
+	}
+	return false
 }
 
 // writePump drains the send channel and drives the Ping heartbeat on the transport.

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -1505,6 +1505,47 @@ func TestResume_MassCloseWhileSuspended_AllOnDisconnect(t *testing.T) {
 	}
 }
 
+// ── Transport error preserved in OnDisconnect ────────────────────────────────
+
+// TestTransportError_PreservedInOnDisconnect verifies that when readPump exits
+// with an error, that error is forwarded to the OnDisconnect callback (not
+// swallowed as nil). Without resume, the hub calls disconnectSession with the
+// readPump error directly. The same error-forwarding logic applies to the
+// Close()+transportDied race paths when resume is enabled (PR #25).
+func TestTransportError_PreservedInOnDisconnect(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 1)
+	disconnectErr := make(chan error, 1)
+
+	srv := wspulse.NewServer(
+		func(r *http.Request) (string, string, error) {
+			return "room", "err-conn", nil
+		},
+		wspulse.WithOnConnect(func(_ wspulse.Connection) {
+			connected <- struct{}{}
+		}),
+		wspulse.WithOnDisconnect(func(_ wspulse.Connection, err error) {
+			disconnectErr <- err
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	mt := injectAndWait(t, srv, "err-conn", "room", connected)
+
+	// Inject a transport error. readPump captures it as readErr and sends
+	// it via transportDied. Without resume, the hub calls disconnectSession
+	// with the error, which fires OnDisconnect with the same error.
+	mt.InjectError(errors.New("network reset"))
+
+	select {
+	case got := <-disconnectErr:
+		assert.ErrorContains(t, got, "network reset",
+			"OnDisconnect should receive the transport error")
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for OnDisconnect")
+	}
+}
+
 // ── Resume: close races with transport died ─────────────────────────────────
 
 func TestResume_CloseRacesTransportDied(t *testing.T) {


### PR DESCRIPTION
## Summary

Preserve the transport error in `OnDisconnect` instead of swallowing it as `nil`. Fixes two race paths in `handleTransportDied` and corrects the error classification so `CloseAbnormalClosure` (1006) is treated as abnormal.

Fixes https://github.com/wspulse/.github/issues/24.

## Changes

- **hub.go**: Forward `message.err` (not `nil`) in both `Close()`+`transportDied` race paths: `detachWS !ok` and post-timer state recheck.
- **session.go**: Extract `isNormalClose()` helper. Only `net.ErrClosed`, `CloseNormalClosure` (1000), and `CloseGoingAway` (1001) are normal. `CloseAbnormalClosure` (1006) now correctly propagates to `OnDisconnect`.
- **session_resume_test.go**: Add `TestTransportError_PreservedInOnDisconnect` -- deterministic, no resume window, no real time. Verified `-race -count=500`.
- **CHANGELOG.md**: Move race fix entries to v0.7.0; minor casing fix.

## Checklist

### Required

- [x] `make check` passes (`fmt` -> `lint` -> `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Bug fix: includes a test that fails before the fix and passes after
- [x] Hub serialization not violated (no session state mutation outside hub goroutine)
