### PR TITLE
refactor: extract requireReceive test helper

### DIFF
--- a/hub_test.go
+++ b/hub_test.go
@@ -75,12 +75,8 @@ func TestOnMessage_CallbackFires(t *testing.T) {
 	require.NoError(t, err)
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	select {
-	case f := <-received:
-		assert.Equal(t, "msg", f.Event)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnMessage callback")
-	}
+	f := requireReceive(t, received, "OnMessage callback")
+	assert.Equal(t, "msg", f.Event)
 }
 
 // ── Broadcast ────────────────────────────────────────────────────────────────
@@ -155,11 +151,7 @@ func TestOnDisconnect_CallbackFires(t *testing.T) {
 	// Simulate transport drop — readPump exits, triggers disconnect.
 	mt.InjectError(errors.New("connection closed"))
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect")
-	}
+	requireReceive(t, disconnected, "OnDisconnect")
 }
 
 // ── Kick ─────────────────────────────────────────────────────────────────────
@@ -183,11 +175,7 @@ func TestKick_ClosesConnection(t *testing.T) {
 
 	require.NoError(t, srv.Kick("test-connection"))
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnection after Kick")
-	}
+	requireReceive(t, disconnected, "disconnection after Kick")
 }
 
 // ── GetConnections ───────────────────────────────────────────────────────────
@@ -239,16 +227,8 @@ func TestDuplicateConnectionID_OldKickedNewReachable(t *testing.T) {
 	mt2 := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt2)
 
-	select {
-	case <-kicked:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for duplicate kick")
-	}
-	select {
-	case <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for second connection")
-	}
+	requireReceive(t, kicked, "duplicate kick")
+	requireReceive(t, connected, "second connection")
 
 	// Verify second connection is reachable.
 	frame := wspulse.Frame{Event: "ok", Payload: []byte(`"after-kick"`)}
@@ -276,20 +256,11 @@ func TestConnectionDone_ClosedOnKick(t *testing.T) {
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	require.NoError(t, srv.Kick(conn.ID()))
 
-	select {
-	case <-conn.Done():
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for Connection.Done()")
-	}
+	requireReceive(t, conn.Done(), "Connection.Done()")
 }
 
 // ── Broadcast to empty room ─────────────────────────────────────────────────
@@ -385,22 +356,14 @@ func TestShutdownFiresOnDisconnect(t *testing.T) {
 	for i := 0; i < count; i++ {
 		mt := newMockTransport()
 		wspulse.InjectTransport(srv, fmt.Sprintf("conn-%d", i+1), "room", mt)
-		select {
-		case <-connected:
-		case <-time.After(time.Second):
-			require.Fail(t, "timed out waiting for connect")
-		}
+		requireReceive(t, connected, "connect")
 	}
 
 	srv.Close()
 
 	for i := 0; i < count; i++ {
-		select {
-		case err := <-disconnected:
-			assert.ErrorIs(t, err, wspulse.ErrServerClosed)
-		case <-time.After(time.Second):
-			require.Fail(t, "timed out waiting for OnDisconnect on shutdown")
-		}
+		err := requireReceive(t, disconnected, "OnDisconnect on shutdown")
+		assert.ErrorIs(t, err, wspulse.ErrServerClosed)
 	}
 }
 
@@ -421,12 +384,7 @@ func TestConnectionSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T) {
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Rapid-fire send to fill the buffer.
 	var gotBufferFull bool

--- a/hub_test.go
+++ b/hub_test.go
@@ -75,7 +75,7 @@ func TestOnMessage_CallbackFires(t *testing.T) {
 	require.NoError(t, err)
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	f := requireReceive(t, received, "OnMessage callback")
+	f := requireReceive(t, received)
 	assert.Equal(t, "msg", f.Event)
 }
 
@@ -151,7 +151,7 @@ func TestOnDisconnect_CallbackFires(t *testing.T) {
 	// Simulate transport drop — readPump exits, triggers disconnect.
 	mt.InjectError(errors.New("connection closed"))
 
-	requireReceive(t, disconnected, "OnDisconnect")
+	requireReceive(t, disconnected)
 }
 
 // ── Kick ─────────────────────────────────────────────────────────────────────
@@ -175,7 +175,7 @@ func TestKick_ClosesConnection(t *testing.T) {
 
 	require.NoError(t, srv.Kick("test-connection"))
 
-	requireReceive(t, disconnected, "disconnection after Kick")
+	requireReceive(t, disconnected)
 }
 
 // ── GetConnections ───────────────────────────────────────────────────────────
@@ -227,8 +227,8 @@ func TestDuplicateConnectionID_OldKickedNewReachable(t *testing.T) {
 	mt2 := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt2)
 
-	requireReceive(t, kicked, "duplicate kick")
-	requireReceive(t, connected, "second connection")
+	requireReceive(t, kicked)
+	requireReceive(t, connected)
 
 	// Verify second connection is reachable.
 	frame := wspulse.Frame{Event: "ok", Payload: []byte(`"after-kick"`)}
@@ -256,11 +256,11 @@ func TestConnectionDone_ClosedOnKick(t *testing.T) {
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	require.NoError(t, srv.Kick(conn.ID()))
 
-	requireReceive(t, conn.Done(), "Connection.Done()")
+	requireReceive(t, conn.Done())
 }
 
 // ── Broadcast to empty room ─────────────────────────────────────────────────
@@ -356,13 +356,13 @@ func TestShutdownFiresOnDisconnect(t *testing.T) {
 	for i := 0; i < count; i++ {
 		mt := newMockTransport()
 		wspulse.InjectTransport(srv, fmt.Sprintf("conn-%d", i+1), "room", mt)
-		requireReceive(t, connected, "connect")
+		requireReceive(t, connected)
 	}
 
 	srv.Close()
 
 	for i := 0; i < count; i++ {
-		err := requireReceive(t, disconnected, "OnDisconnect on shutdown")
+		err := requireReceive(t, disconnected)
 		assert.ErrorIs(t, err, wspulse.ErrServerClosed)
 	}
 }
@@ -384,7 +384,7 @@ func TestConnectionSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T) {
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Rapid-fire send to fill the buffer.
 	var gotBufferFull bool

--- a/metrics_hook_test.go
+++ b/metrics_hook_test.go
@@ -75,11 +75,7 @@ func TestMetricsCollector_ConnectionLifecycle(t *testing.T) {
 
 	// Kill transport.
 	mt.InjectError(errors.New("closed"))
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect")
-	}
+	requireReceive(t, disconnected, "disconnect")
 
 	assert.Equal(t, 1, rec.countByName("ConnectionClosed"), "ConnectionClosed")
 	assert.Equal(t, 1, rec.countByName("RoomDestroyed"), "RoomDestroyed")
@@ -127,11 +123,7 @@ func TestMetricsCollector_MessageFlow(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "test"})
 	mt1.InjectMessage(websocket.TextMessage, encoded)
 
-	select {
-	case <-broadcastDone:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for broadcast")
-	}
+	requireReceive(t, broadcastDone, "broadcast")
 
 	// Wait for MessageSent to fire for both connections.
 	deadline := time.Now().Add(time.Second)
@@ -209,12 +201,7 @@ func TestMetricsCollector_FrameDropped_SendFull(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "drop-conn", "drop-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	frame := wspulse.Frame{Event: "fill", Payload: []byte(`{}`)}
 	var gotBufferFull bool
@@ -305,11 +292,7 @@ func TestMetricsCollector_PongTimeout(t *testing.T) {
 	// Inject a timeout error to simulate pong timeout.
 	mt.InjectError(&timeoutError{})
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect")
-	}
+	requireReceive(t, disconnected, "disconnect")
 
 	assert.Equal(t, 1, rec.countByName("PongTimeout"), "PongTimeout")
 }

--- a/metrics_hook_test.go
+++ b/metrics_hook_test.go
@@ -75,7 +75,7 @@ func TestMetricsCollector_ConnectionLifecycle(t *testing.T) {
 
 	// Kill transport.
 	mt.InjectError(errors.New("closed"))
-	requireReceive(t, disconnected, "disconnect")
+	requireReceive(t, disconnected)
 
 	assert.Equal(t, 1, rec.countByName("ConnectionClosed"), "ConnectionClosed")
 	assert.Equal(t, 1, rec.countByName("RoomDestroyed"), "RoomDestroyed")
@@ -123,7 +123,7 @@ func TestMetricsCollector_MessageFlow(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "test"})
 	mt1.InjectMessage(websocket.TextMessage, encoded)
 
-	requireReceive(t, broadcastDone, "broadcast")
+	requireReceive(t, broadcastDone)
 
 	// Wait for MessageSent to fire for both connections.
 	deadline := time.Now().Add(time.Second)
@@ -201,7 +201,7 @@ func TestMetricsCollector_FrameDropped_SendFull(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "drop-conn", "drop-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	frame := wspulse.Frame{Event: "fill", Payload: []byte(`{}`)}
 	var gotBufferFull bool
@@ -292,7 +292,7 @@ func TestMetricsCollector_PongTimeout(t *testing.T) {
 	// Inject a timeout error to simulate pong timeout.
 	mt.InjectError(&timeoutError{})
 
-	requireReceive(t, disconnected, "disconnect")
+	requireReceive(t, disconnected)
 
 	assert.Equal(t, 1, rec.countByName("PongTimeout"), "PongTimeout")
 }

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -44,7 +44,7 @@ func TestReadPumpPanicRecovery(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	requireReceive(t, disconnected, "OnDisconnect after panic")
+	requireReceive(t, disconnected)
 }
 
 func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
@@ -70,7 +70,7 @@ func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	got := requireReceive(t, disconnectErr, "OnDisconnect")
+	got := requireReceive(t, disconnectErr)
 	var pe *wspulse.PanicError
 	require.ErrorAs(t, got, &pe)
 	assert.Equal(t, "typed-boom", pe.Value)
@@ -104,7 +104,7 @@ func TestReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "valid"})
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	f := requireReceive(t, received, "valid frame after malformed one")
+	f := requireReceive(t, received)
 	assert.Equal(t, "valid", f.Event)
 }
 
@@ -289,7 +289,7 @@ func TestClose_BlocksUntilHubExits(t *testing.T) {
 		close(done)
 	}()
 
-	requireReceive(t, done, "Close() did not return within timeout")
+	requireReceive(t, done)
 }
 
 // ── Connection.Send after Close ─────────────────────────────────────────────
@@ -311,11 +311,11 @@ func TestConnectionSend_AfterClose_ReturnsErrConnectionClosed(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Kill transport to trigger disconnect.
 	mt.InjectError(errors.New("closed"))
-	requireReceive(t, disconnected, "disconnect")
+	requireReceive(t, disconnected)
 
 	err := conn.Send(wspulse.Frame{Event: "after-close"})
 	assert.ErrorIs(t, err, wspulse.ErrConnectionClosed)
@@ -340,7 +340,7 @@ func TestBroadcast_SkipsClosedSession(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("closed"))
-	requireReceive(t, disconnected, "disconnect")
+	requireReceive(t, disconnected)
 
 	// Broadcast to the room — should not panic or error despite closed session.
 	err := srv.Broadcast("test-room", wspulse.Frame{Event: "after-close"})
@@ -366,7 +366,7 @@ func TestGetConnections_EmptyAfterDisconnect(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("closed"))
-	requireReceive(t, disconnected, "disconnect")
+	requireReceive(t, disconnected)
 
 	// Poll until hub processes removal instead of fixed sleep.
 	deadline := time.Now().Add(time.Second)
@@ -425,7 +425,7 @@ func TestConnectionSend_EncodeError_ReturnsError(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	err := conn.Send(wspulse.Frame{Event: "test"})
 	assert.Error(t, err)
@@ -458,7 +458,7 @@ func TestNoOnMessage_ReadPumpStillProcesses(t *testing.T) {
 	// Then kill the transport.
 	mt.InjectError(errors.New("closed"))
 
-	requireReceive(t, disconnected, "disconnect")
+	requireReceive(t, disconnected)
 }
 
 // ── HTTP-layer tests (use httptest, no mock transport) ──────────────────────
@@ -517,7 +517,7 @@ func TestServeHTTP_EmptyConnectionID_GetsUUID(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 	assert.NotEmpty(t, conn.ID(), "expected server-generated UUID")
 }
 
@@ -540,11 +540,11 @@ func TestConnectionSend_DoneClosesDuringEnqueue(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Kick to close the session.
 	require.NoError(t, srv.Kick("test-connection"))
-	requireReceive(t, disconnected, "disconnect")
+	requireReceive(t, disconnected)
 
 	// Send after done is closed.
 	err := conn.Send(wspulse.Frame{Event: "late"})
@@ -581,7 +581,7 @@ func TestCloseWhileConnecting_NoLeak(t *testing.T) {
 
 	// Wait for all connections to register before closing.
 	for i := 0; i < count; i++ {
-		requireReceive(t, connected, "connect")
+		requireReceive(t, connected)
 	}
 	srv.Close()
 	wg.Wait()

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -44,11 +44,7 @@ func TestReadPumpPanicRecovery(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect after panic")
-	}
+	requireReceive(t, disconnected, "OnDisconnect after panic")
 }
 
 func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
@@ -74,16 +70,12 @@ func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	select {
-	case got := <-disconnectErr:
-		var pe *wspulse.PanicError
-		require.ErrorAs(t, got, &pe)
-		assert.Equal(t, "typed-boom", pe.Value)
-		require.NotEmpty(t, pe.Stack)
-		assert.Equal(t, "wspulse: onMessage panic: typed-boom", pe.Error())
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect")
-	}
+	got := requireReceive(t, disconnectErr, "OnDisconnect")
+	var pe *wspulse.PanicError
+	require.ErrorAs(t, got, &pe)
+	assert.Equal(t, "typed-boom", pe.Value)
+	require.NotEmpty(t, pe.Stack)
+	assert.Equal(t, "wspulse: onMessage panic: typed-boom", pe.Error())
 }
 
 // ── ReadPump malformed frame ────────────────────────────────────────────────
@@ -112,12 +104,8 @@ func TestReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
 	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "valid"})
 	mt.InjectMessage(websocket.TextMessage, encoded)
 
-	select {
-	case f := <-received:
-		assert.Equal(t, "valid", f.Event)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for valid frame after malformed one")
-	}
+	f := requireReceive(t, received, "valid frame after malformed one")
+	assert.Equal(t, "valid", f.Event)
 }
 
 // ── Broadcast drop-oldest with slow client ──────────────────────────────────
@@ -301,11 +289,7 @@ func TestClose_BlocksUntilHubExits(t *testing.T) {
 		close(done)
 	}()
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		require.Fail(t, "Close() did not return within timeout")
-	}
+	requireReceive(t, done, "Close() did not return within timeout")
 }
 
 // ── Connection.Send after Close ─────────────────────────────────────────────
@@ -327,20 +311,11 @@ func TestConnectionSend_AfterClose_ReturnsErrConnectionClosed(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Kill transport to trigger disconnect.
 	mt.InjectError(errors.New("closed"))
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect")
-	}
+	requireReceive(t, disconnected, "disconnect")
 
 	err := conn.Send(wspulse.Frame{Event: "after-close"})
 	assert.ErrorIs(t, err, wspulse.ErrConnectionClosed)
@@ -365,11 +340,7 @@ func TestBroadcast_SkipsClosedSession(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("closed"))
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect")
-	}
+	requireReceive(t, disconnected, "disconnect")
 
 	// Broadcast to the room — should not panic or error despite closed session.
 	err := srv.Broadcast("test-room", wspulse.Frame{Event: "after-close"})
@@ -395,11 +366,7 @@ func TestGetConnections_EmptyAfterDisconnect(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("closed"))
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect")
-	}
+	requireReceive(t, disconnected, "disconnect")
 
 	// Poll until hub processes removal instead of fixed sleep.
 	deadline := time.Now().Add(time.Second)
@@ -458,12 +425,7 @@ func TestConnectionSend_EncodeError_ReturnsError(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	err := conn.Send(wspulse.Frame{Event: "test"})
 	assert.Error(t, err)
@@ -496,11 +458,7 @@ func TestNoOnMessage_ReadPumpStillProcesses(t *testing.T) {
 	// Then kill the transport.
 	mt.InjectError(errors.New("closed"))
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect")
-	}
+	requireReceive(t, disconnected, "disconnect")
 }
 
 // ── HTTP-layer tests (use httptest, no mock transport) ──────────────────────
@@ -559,12 +517,8 @@ func TestServeHTTP_EmptyConnectionID_GetsUUID(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 
-	select {
-	case conn := <-connected:
-		assert.NotEmpty(t, conn.ID(), "expected server-generated UUID")
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
+	assert.NotEmpty(t, conn.ID(), "expected server-generated UUID")
 }
 
 // ── Connection.Send with done closed ────────────────────────────────────────
@@ -586,20 +540,11 @@ func TestConnectionSend_DoneClosesDuringEnqueue(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Kick to close the session.
 	require.NoError(t, srv.Kick("test-connection"))
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect")
-	}
+	requireReceive(t, disconnected, "disconnect")
 
 	// Send after done is closed.
 	err := conn.Send(wspulse.Frame{Event: "late"})
@@ -636,11 +581,7 @@ func TestCloseWhileConnecting_NoLeak(t *testing.T) {
 
 	// Wait for all connections to register before closing.
 	for i := 0; i < count; i++ {
-		select {
-		case <-connected:
-		case <-time.After(time.Second):
-			require.Fail(t, "timed out waiting for connect")
-		}
+		requireReceive(t, connected, "connect")
 	}
 	srv.Close()
 	wg.Wait()

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -146,7 +146,7 @@ func TestResume_GraceExpires_FiresOnDisconnect(t *testing.T) {
 	// Fire the grace timer.
 	fc.Fire(0)
 
-	requireReceive(t, disconnected, "OnDisconnect after grace expiry")
+	requireReceive(t, disconnected)
 }
 
 // ── Resume: buffered frames delivered ───────────────────────────────────────
@@ -245,7 +245,7 @@ func TestResume_KickBypassesWindow(t *testing.T) {
 	// Kick should bypass the resume window and fire OnDisconnect immediately.
 	require.NoError(t, srv.Kick("test-connection"))
 
-	requireReceive(t, disconnected, "OnDisconnect after Kick")
+	requireReceive(t, disconnected)
 }
 
 // ── Resume: no resume window → disconnects immediately ──────────────────────
@@ -276,7 +276,7 @@ func TestResume_NoResumeWindow_DisconnectsImmediately(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("transport closed"))
 
-	requireReceive(t, disconnected, "OnDisconnect (no resume window)")
+	requireReceive(t, disconnected)
 }
 
 // ── Resume: server close terminates suspended ───────────────────────────────
@@ -315,7 +315,7 @@ func TestResume_ServerCloseTerminatesSuspended(t *testing.T) {
 	// Close server while session is suspended.
 	srv.Close()
 
-	err := requireReceive(t, disconnected, "OnDisconnect from server close on suspended session")
+	err := requireReceive(t, disconnected)
 	assert.ErrorIs(t, err, wspulse.ErrServerClosed)
 }
 
@@ -400,16 +400,16 @@ func TestResume_ConnectionCloseWhileSuspended(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Drop transport to enter suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Close the connection while suspended — should fire OnDisconnect immediately.
 	require.NoError(t, conn.Close())
 
-	requireReceive(t, disconnected, "OnDisconnect after Connection.Close on suspended session")
+	requireReceive(t, disconnected)
 }
 
 // ── Transport callbacks: drop fires on suspend ──────────────────────────────
@@ -440,7 +440,7 @@ func TestOnTransportDrop_FiresOnSuspend(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("test: connection reset"))
 
-	_ = requireReceive(t, dropErr, "OnTransportDrop")
+	_ = requireReceive(t, dropErr)
 }
 
 // ── Transport callbacks: restore fires on resume ────────────────────────────
@@ -516,7 +516,7 @@ func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("transport closed"))
 
-	requireReceive(t, disconnected, "OnDisconnect")
+	requireReceive(t, disconnected)
 
 	assert.False(t, dropFired.Load(), "OnTransportDrop should not fire without resume window")
 	assert.False(t, restoreFired.Load(), "OnTransportRestore should not fire without resume window")
@@ -559,13 +559,13 @@ func TestResume_ConcurrentReconnect_NoRace(t *testing.T) {
 		wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
 		if i == 0 {
-			requireReceive(t, connected, "cycle %d: waiting for connect", i)
+			requireReceive(t, connected)
 		} else {
-			requireReceive(t, restored, "cycle %d: waiting for transport restore", i)
+			requireReceive(t, restored)
 		}
 
 		mt.InjectError(errors.New("transport closed"))
-		requireReceive(t, dropped, "cycle %d: waiting for transport drop", i)
+		requireReceive(t, dropped)
 	}
 }
 
@@ -611,7 +611,7 @@ func TestResume_ConcurrentBroadcastDuringResume_NoRace(t *testing.T) {
 	}
 
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Reconnect while broadcasts are still in flight.
 	mt2 := newMockTransport()
@@ -661,11 +661,11 @@ func TestResume_StaleClosedSession_Reconnect(t *testing.T) {
 
 	// Close transport and fire the grace timer.
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "OnTransportDrop")
+	requireReceive(t, dropped)
 
 	fc.Fire(0)
 
-	requireReceive(t, disconnected, "grace expiry disconnect")
+	requireReceive(t, disconnected)
 
 	// Reconnect with the same connectionID — hits stateClosed branch.
 	mt2 := injectAndWait(t, srv, "test-connection", "test-room", connected)
@@ -716,13 +716,13 @@ func TestResume_MultipleRapidCycles(t *testing.T) {
 		wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
 		if i == 0 {
-			requireReceive(t, connected, "cycle %d: waiting for connect", i)
+			requireReceive(t, connected)
 		} else {
-			requireReceive(t, restored, "cycle %d: waiting for transport restore", i)
+			requireReceive(t, restored)
 		}
 
 		mt.InjectError(errors.New("transport closed"))
-		requireReceive(t, dropped, "cycle %d: waiting for transport drop", i)
+		requireReceive(t, dropped)
 	}
 }
 
@@ -755,11 +755,11 @@ func TestResume_GraceExpiresAfterConnectionClose(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Close transport to enter suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "OnTransportDrop")
+	requireReceive(t, dropped)
 
 	// Application calls Close() on the Connection while suspended.
 	require.NoError(t, conn.Close())
@@ -811,7 +811,7 @@ func TestResume_KickWhileConnected_TransportDiedHandled(t *testing.T) {
 
 	require.NoError(t, srv.Kick("test-connection"))
 
-	requireReceive(t, disconnected, "OnDisconnect")
+	requireReceive(t, disconnected)
 	// Wait for hub to finish deferred cleanup (connection removal).
 	deadline := time.Now().Add(time.Second)
 	for len(srv.GetConnections("test-room")) > 0 {
@@ -858,7 +858,7 @@ func TestResume_DuplicateID_WhileConnected_KicksOld(t *testing.T) {
 	// Second connection with same ID while first is still connected.
 	mt2 := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt2)
-	requireReceive(t, kicked, "duplicate kick")
+	requireReceive(t, kicked)
 }
 
 // ── Resume: writePump stops on pumpQuit ─────────────────────────────────────
@@ -905,7 +905,7 @@ func TestResume_WritePumpStopsOnPumpQuit(t *testing.T) {
 
 	// Close transport to suspend, writePump gets pumpQuit.
 	mt1.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Reconnect — triggers attachWS, which waits for old pumpDone.
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
@@ -957,7 +957,7 @@ func TestResume_WritePumpExitsViaPumpQuit(t *testing.T) {
 	// Close client transport to trigger suspend. With long ping period,
 	// writePump won't attempt any writes before pumpQuit fires.
 	mt1.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Reconnect to prove the old writePump has exited correctly.
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
@@ -999,7 +999,7 @@ func TestResume_ConnectionCloseWhileSuspended_ThenReconnect(t *testing.T) {
 
 	// Close transport to enter suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Get the connection reference and call Close() on it.
 	connections := srv.GetConnections("test-room")
@@ -1064,7 +1064,7 @@ func TestResume_StaleClosedSession_OnDisconnectFires(t *testing.T) {
 
 	// Suspend the session by dropping the transport.
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Call Close() on the suspended session.
 	conns := srv.GetConnections("test-room")
@@ -1076,7 +1076,7 @@ func TestResume_StaleClosedSession_OnDisconnectFires(t *testing.T) {
 	mt2 := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// The old session's onDisconnect should fire.
-	requireReceive(t, disconnected, "onDisconnect from stale session")
+	requireReceive(t, disconnected)
 
 	// Verify new session works.
 	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "alive"}))
@@ -1189,11 +1189,11 @@ func TestResume_ConnectionCloseWhileSuspended_FiresOnDisconnect(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Drop the transport — session enters suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Confirm the session is still registered (suspended).
 	require.NotEmpty(t, srv.GetConnections("test-room"),
@@ -1203,7 +1203,7 @@ func TestResume_ConnectionCloseWhileSuspended_FiresOnDisconnect(t *testing.T) {
 	_ = conn.Close()
 
 	// onDisconnect must fire.
-	requireReceive(t, disconnected, "onDisconnect after Connection.Close() on suspended session")
+	requireReceive(t, disconnected)
 
 	// Session must be removed from hub maps after onDisconnect.
 	deadline := time.Now().Add(time.Second)
@@ -1249,11 +1249,11 @@ func TestResume_ConnectionClose_ImmediateOnDisconnect(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Drop the transport — session enters suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "transport drop")
+	requireReceive(t, dropped)
 
 	// Application calls Close() on the suspended session.
 	start := time.Now()
@@ -1404,7 +1404,7 @@ func TestTransportError_PreservedInOnDisconnect(t *testing.T) {
 	// with the error, which fires OnDisconnect with the same error.
 	mt.InjectError(errors.New("network reset"))
 
-	got := requireReceive(t, disconnectErr, "OnDisconnect")
+	got := requireReceive(t, disconnectErr)
 	assert.ErrorContains(t, got, "network reset",
 		"OnDisconnect should receive the transport error")
 }
@@ -1596,7 +1596,7 @@ func TestResume_StaleGraceTimer(t *testing.T) {
 	// Cycle 2: reconnect (resume), then drop again. Timer 1 (epoch=2).
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 	mt2.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "second drop")
+	requireReceive(t, dropped)
 
 	// Cycle 3: reconnect again (resume).
 	mt3 := reconnect(t, srv, "test-connection", "test-room", restored)
@@ -1647,14 +1647,14 @@ func TestConnectionClose_StateClosed_TransportDied(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Close the session externally — this sets state to stateClosed
 	// and closes done. writePump sees done, closes transport.
 	// readPump gets a read error and sends transportDied.
 	_ = conn.Close()
 
-	requireReceive(t, disconnected, "onDisconnect after Connection.Close()")
+	requireReceive(t, disconnected)
 }
 
 // ── Connection.Close stateClosed then resume attempt ────────────────────────
@@ -1684,12 +1684,12 @@ func TestConnectionClose_StateClosed_Resume(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	conn := requireReceive(t, connected, "connect")
+	conn := requireReceive(t, connected)
 
 	// Close externally — state becomes stateClosed before transport dies.
 	_ = conn.Close()
 
-	requireReceive(t, disconnected, "onDisconnect")
+	requireReceive(t, disconnected)
 }
 
 // ── OnTransportDrop: grace expires then disconnect ──────────────────────────
@@ -1718,18 +1718,18 @@ func TestOnTransportDrop_GraceExpires_ThenDisconnect(t *testing.T) {
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
-	e := requireReceive(t, events, "connect event")
+	e := requireReceive(t, events)
 	require.Equal(t, "connect", e, "first event")
 
 	mt.InjectError(errors.New("transport closed"))
 
 	// Expect: drop fires first, then disconnect fires after grace expires.
-	e = requireReceive(t, events, "drop event")
+	e = requireReceive(t, events)
 	require.Equal(t, "drop", e, "second event")
 
 	fc.Fire(0)
 
-	e = requireReceive(t, events, "disconnect event")
+	e = requireReceive(t, events)
 	require.Equal(t, "disconnect", e, "third event")
 }
 
@@ -1774,7 +1774,7 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt2)
 
 	// Wait for restore event first.
-	e := requireReceive(t, events, "restore event")
+	e := requireReceive(t, events)
 	require.Equal(t, "restore", e, "first event after reconnect")
 	_ = restored // not used here
 
@@ -1783,7 +1783,7 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 	require.NoError(t, err)
 	mt2.InjectMessage(wspulse.TextMessage, encoded)
 
-	e = requireReceive(t, events, "message event")
+	e = requireReceive(t, events)
 	require.Equal(t, "message", e, "second event after reconnect")
 }
 
@@ -1872,11 +1872,11 @@ func TestOnTransportRestore_NotFiredOnClosedSession(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	requireReceive(t, connected, "first connect")
+	requireReceive(t, connected)
 
 	// Drop transport — session suspends, OnTransportDrop fires and calls Close().
 	mt.InjectError(errors.New("transport closed"))
-	requireReceive(t, dropped, "OnTransportDrop")
+	requireReceive(t, dropped)
 
 	// Reconnect with the same connectionID immediately. Depending on
 	// hub event ordering, the old closed session may or may not still

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -146,11 +146,7 @@ func TestResume_GraceExpires_FiresOnDisconnect(t *testing.T) {
 	// Fire the grace timer.
 	fc.Fire(0)
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect after grace expiry")
-	}
+	requireReceive(t, disconnected, "OnDisconnect after grace expiry")
 }
 
 // ── Resume: buffered frames delivered ───────────────────────────────────────
@@ -249,11 +245,7 @@ func TestResume_KickBypassesWindow(t *testing.T) {
 	// Kick should bypass the resume window and fire OnDisconnect immediately.
 	require.NoError(t, srv.Kick("test-connection"))
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect after Kick")
-	}
+	requireReceive(t, disconnected, "OnDisconnect after Kick")
 }
 
 // ── Resume: no resume window → disconnects immediately ──────────────────────
@@ -284,11 +276,7 @@ func TestResume_NoResumeWindow_DisconnectsImmediately(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("transport closed"))
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect (no resume window)")
-	}
+	requireReceive(t, disconnected, "OnDisconnect (no resume window)")
 }
 
 // ── Resume: server close terminates suspended ───────────────────────────────
@@ -327,12 +315,8 @@ func TestResume_ServerCloseTerminatesSuspended(t *testing.T) {
 	// Close server while session is suspended.
 	srv.Close()
 
-	select {
-	case err := <-disconnected:
-		assert.ErrorIs(t, err, wspulse.ErrServerClosed)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect from server close on suspended session")
-	}
+	err := requireReceive(t, disconnected, "OnDisconnect from server close on suspended session")
+	assert.ErrorIs(t, err, wspulse.ErrServerClosed)
 }
 
 // ── Resume: broadcast while suspended ───────────────────────────────────────
@@ -416,29 +400,16 @@ func TestResume_ConnectionCloseWhileSuspended(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Drop transport to enter suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Close the connection while suspended — should fire OnDisconnect immediately.
 	require.NoError(t, conn.Close())
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect after Connection.Close on suspended session")
-	}
+	requireReceive(t, disconnected, "OnDisconnect after Connection.Close on suspended session")
 }
 
 // ── Transport callbacks: drop fires on suspend ──────────────────────────────
@@ -469,12 +440,7 @@ func TestOnTransportDrop_FiresOnSuspend(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("test: connection reset"))
 
-	select {
-	case <-dropErr:
-		// Callback fired — error may be nil for normal close.
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnTransportDrop")
-	}
+	_ = requireReceive(t, dropErr, "OnTransportDrop")
 }
 
 // ── Transport callbacks: restore fires on resume ────────────────────────────
@@ -550,11 +516,7 @@ func TestTransportCallbacks_NotFired_WithoutResumeWindow(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 	mt.InjectError(errors.New("transport closed"))
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect")
-	}
+	requireReceive(t, disconnected, "OnDisconnect")
 
 	assert.False(t, dropFired.Load(), "OnTransportDrop should not fire without resume window")
 	assert.False(t, restoreFired.Load(), "OnTransportRestore should not fire without resume window")
@@ -597,25 +559,13 @@ func TestResume_ConcurrentReconnect_NoRace(t *testing.T) {
 		wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
 		if i == 0 {
-			select {
-			case <-connected:
-			case <-time.After(time.Second):
-				require.Failf(t, "timed out", "cycle %d: waiting for connect", i)
-			}
+			requireReceive(t, connected, "cycle %d: waiting for connect", i)
 		} else {
-			select {
-			case <-restored:
-			case <-time.After(time.Second):
-				require.Failf(t, "timed out", "cycle %d: waiting for transport restore", i)
-			}
+			requireReceive(t, restored, "cycle %d: waiting for transport restore", i)
 		}
 
 		mt.InjectError(errors.New("transport closed"))
-		select {
-		case <-dropped:
-		case <-time.After(time.Second):
-			require.Failf(t, "timed out", "cycle %d: waiting for transport drop", i)
-		}
+		requireReceive(t, dropped, "cycle %d: waiting for transport drop", i)
 	}
 }
 
@@ -661,11 +611,7 @@ func TestResume_ConcurrentBroadcastDuringResume_NoRace(t *testing.T) {
 	}
 
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Reconnect while broadcasts are still in flight.
 	mt2 := newMockTransport()
@@ -715,19 +661,11 @@ func TestResume_StaleClosedSession_Reconnect(t *testing.T) {
 
 	// Close transport and fire the grace timer.
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnTransportDrop")
-	}
+	requireReceive(t, dropped, "OnTransportDrop")
 
 	fc.Fire(0)
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for grace expiry disconnect")
-	}
+	requireReceive(t, disconnected, "grace expiry disconnect")
 
 	// Reconnect with the same connectionID — hits stateClosed branch.
 	mt2 := injectAndWait(t, srv, "test-connection", "test-room", connected)
@@ -778,25 +716,13 @@ func TestResume_MultipleRapidCycles(t *testing.T) {
 		wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
 		if i == 0 {
-			select {
-			case <-connected:
-			case <-time.After(time.Second):
-				require.Failf(t, "timed out", "cycle %d: waiting for connect", i)
-			}
+			requireReceive(t, connected, "cycle %d: waiting for connect", i)
 		} else {
-			select {
-			case <-restored:
-			case <-time.After(time.Second):
-				require.Failf(t, "timed out", "cycle %d: waiting for transport restore", i)
-			}
+			requireReceive(t, restored, "cycle %d: waiting for transport restore", i)
 		}
 
 		mt.InjectError(errors.New("transport closed"))
-		select {
-		case <-dropped:
-		case <-time.After(time.Second):
-			require.Failf(t, "timed out", "cycle %d: waiting for transport drop", i)
-		}
+		requireReceive(t, dropped, "cycle %d: waiting for transport drop", i)
 	}
 }
 
@@ -829,20 +755,11 @@ func TestResume_GraceExpiresAfterConnectionClose(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Close transport to enter suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnTransportDrop")
-	}
+	requireReceive(t, dropped, "OnTransportDrop")
 
 	// Application calls Close() on the Connection while suspended.
 	require.NoError(t, conn.Close())
@@ -894,11 +811,7 @@ func TestResume_KickWhileConnected_TransportDiedHandled(t *testing.T) {
 
 	require.NoError(t, srv.Kick("test-connection"))
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect")
-	}
+	requireReceive(t, disconnected, "OnDisconnect")
 	// Wait for hub to finish deferred cleanup (connection removal).
 	deadline := time.Now().Add(time.Second)
 	for len(srv.GetConnections("test-room")) > 0 {
@@ -945,11 +858,7 @@ func TestResume_DuplicateID_WhileConnected_KicksOld(t *testing.T) {
 	// Second connection with same ID while first is still connected.
 	mt2 := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt2)
-	select {
-	case <-kicked:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for duplicate kick")
-	}
+	requireReceive(t, kicked, "duplicate kick")
 }
 
 // ── Resume: writePump stops on pumpQuit ─────────────────────────────────────
@@ -996,11 +905,7 @@ func TestResume_WritePumpStopsOnPumpQuit(t *testing.T) {
 
 	// Close transport to suspend, writePump gets pumpQuit.
 	mt1.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Reconnect — triggers attachWS, which waits for old pumpDone.
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
@@ -1052,11 +957,7 @@ func TestResume_WritePumpExitsViaPumpQuit(t *testing.T) {
 	// Close client transport to trigger suspend. With long ping period,
 	// writePump won't attempt any writes before pumpQuit fires.
 	mt1.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Reconnect to prove the old writePump has exited correctly.
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
@@ -1098,11 +999,7 @@ func TestResume_ConnectionCloseWhileSuspended_ThenReconnect(t *testing.T) {
 
 	// Close transport to enter suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Get the connection reference and call Close() on it.
 	connections := srv.GetConnections("test-room")
@@ -1167,11 +1064,7 @@ func TestResume_StaleClosedSession_OnDisconnectFires(t *testing.T) {
 
 	// Suspend the session by dropping the transport.
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Call Close() on the suspended session.
 	conns := srv.GetConnections("test-room")
@@ -1183,11 +1076,7 @@ func TestResume_StaleClosedSession_OnDisconnectFires(t *testing.T) {
 	mt2 := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// The old session's onDisconnect should fire.
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for onDisconnect from stale session")
-	}
+	requireReceive(t, disconnected, "onDisconnect from stale session")
 
 	// Verify new session works.
 	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "alive"}))
@@ -1300,20 +1189,11 @@ func TestResume_ConnectionCloseWhileSuspended_FiresOnDisconnect(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Drop the transport — session enters suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Confirm the session is still registered (suspended).
 	require.NotEmpty(t, srv.GetConnections("test-room"),
@@ -1323,11 +1203,7 @@ func TestResume_ConnectionCloseWhileSuspended_FiresOnDisconnect(t *testing.T) {
 	_ = conn.Close()
 
 	// onDisconnect must fire.
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "onDisconnect did not fire after Connection.Close() on suspended session")
-	}
+	requireReceive(t, disconnected, "onDisconnect after Connection.Close() on suspended session")
 
 	// Session must be removed from hub maps after onDisconnect.
 	deadline := time.Now().Add(time.Second)
@@ -1373,20 +1249,11 @@ func TestResume_ConnectionClose_ImmediateOnDisconnect(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Drop the transport — session enters suspended state.
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for transport drop")
-	}
+	requireReceive(t, dropped, "transport drop")
 
 	// Application calls Close() on the suspended session.
 	start := time.Now()
@@ -1537,13 +1404,9 @@ func TestTransportError_PreservedInOnDisconnect(t *testing.T) {
 	// with the error, which fires OnDisconnect with the same error.
 	mt.InjectError(errors.New("network reset"))
 
-	select {
-	case got := <-disconnectErr:
-		assert.ErrorContains(t, got, "network reset",
-			"OnDisconnect should receive the transport error")
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnDisconnect")
-	}
+	got := requireReceive(t, disconnectErr, "OnDisconnect")
+	assert.ErrorContains(t, got, "network reset",
+		"OnDisconnect should receive the transport error")
 }
 
 // ── Resume: close races with transport died ─────────────────────────────────
@@ -1733,11 +1596,7 @@ func TestResume_StaleGraceTimer(t *testing.T) {
 	// Cycle 2: reconnect (resume), then drop again. Timer 1 (epoch=2).
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 	mt2.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for second drop")
-	}
+	requireReceive(t, dropped, "second drop")
 
 	// Cycle 3: reconnect again (resume).
 	mt3 := reconnect(t, srv, "test-connection", "test-room", restored)
@@ -1788,23 +1647,14 @@ func TestConnectionClose_StateClosed_TransportDied(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Close the session externally — this sets state to stateClosed
 	// and closes done. writePump sees done, closes transport.
 	// readPump gets a read error and sends transportDied.
 	_ = conn.Close()
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for onDisconnect after Connection.Close()")
-	}
+	requireReceive(t, disconnected, "onDisconnect after Connection.Close()")
 }
 
 // ── Connection.Close stateClosed then resume attempt ────────────────────────
@@ -1834,21 +1684,12 @@ func TestConnectionClose_StateClosed_Resume(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	var conn wspulse.Connection
-	select {
-	case conn = <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect")
-	}
+	conn := requireReceive(t, connected, "connect")
 
 	// Close externally — state becomes stateClosed before transport dies.
 	_ = conn.Close()
 
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for onDisconnect")
-	}
+	requireReceive(t, disconnected, "onDisconnect")
 }
 
 // ── OnTransportDrop: grace expires then disconnect ──────────────────────────
@@ -1877,31 +1718,19 @@ func TestOnTransportDrop_GraceExpires_ThenDisconnect(t *testing.T) {
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 
-	select {
-	case e := <-events:
-		require.Equal(t, "connect", e, "first event")
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for connect event")
-	}
+	e := requireReceive(t, events, "connect event")
+	require.Equal(t, "connect", e, "first event")
 
 	mt.InjectError(errors.New("transport closed"))
 
 	// Expect: drop fires first, then disconnect fires after grace expires.
-	select {
-	case e := <-events:
-		require.Equal(t, "drop", e, "second event")
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for drop event")
-	}
+	e = requireReceive(t, events, "drop event")
+	require.Equal(t, "drop", e, "second event")
 
 	fc.Fire(0)
 
-	select {
-	case e := <-events:
-		require.Equal(t, "disconnect", e, "third event")
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for disconnect event")
-	}
+	e = requireReceive(t, events, "disconnect event")
+	require.Equal(t, "disconnect", e, "third event")
 }
 
 // ── OnTransportRestore: then OnMessage ──────────────────────────────────────
@@ -1945,12 +1774,8 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt2)
 
 	// Wait for restore event first.
-	select {
-	case e := <-events:
-		require.Equal(t, "restore", e, "first event after reconnect")
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for restore event")
-	}
+	e := requireReceive(t, events, "restore event")
+	require.Equal(t, "restore", e, "first event after reconnect")
 	_ = restored // not used here
 
 	// Now send a message on the new transport.
@@ -1958,12 +1783,8 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 	require.NoError(t, err)
 	mt2.InjectMessage(wspulse.TextMessage, encoded)
 
-	select {
-	case e := <-events:
-		require.Equal(t, "message", e, "second event after reconnect")
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for message event")
-	}
+	e = requireReceive(t, events, "message event")
+	require.Equal(t, "message", e, "second event after reconnect")
 }
 
 // ── OnTransportRestore: fires after state connected ─────────────────────────
@@ -2051,19 +1872,11 @@ func TestOnTransportRestore_NotFiredOnClosedSession(t *testing.T) {
 
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
-	select {
-	case <-connected:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for first connect")
-	}
+	requireReceive(t, connected, "first connect")
 
 	// Drop transport — session suspends, OnTransportDrop fires and calls Close().
 	mt.InjectError(errors.New("transport closed"))
-	select {
-	case <-dropped:
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for OnTransportDrop")
-	}
+	requireReceive(t, dropped, "OnTransportDrop")
 
 	// Reconnect with the same connectionID immediately. Depending on
 	// hub event ordering, the old closed session may or may not still

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -8,7 +8,7 @@ import (
 // bug and the channel never signals, `go test -timeout` (default 10 min) kills
 // the binary with a full goroutine stack dump — far more useful than a short
 // time.After that becomes a flaky-test source under -race -count=N.
-func requireReceive[T any](t *testing.T, ch <-chan T, _ ...any) T {
+func requireReceive[T any](t *testing.T, ch <-chan T) T {
 	t.Helper()
 	return <-ch
 }

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -1,0 +1,14 @@
+package wspulse_test
+
+import (
+	"testing"
+)
+
+// requireReceive blocks until a value arrives on ch. If production code has a
+// bug and the channel never signals, `go test -timeout` (default 10 min) kills
+// the binary with a full goroutine stack dump — far more useful than a short
+// time.After that becomes a flaky-test source under -race -count=N.
+func requireReceive[T any](t *testing.T, ch <-chan T, _ ...any) T {
+	t.Helper()
+	return <-ch
+}


### PR DESCRIPTION
## Summary

Extract a generic `requireReceive[T]` helper to replace 57 inline `select + time.After` blocks scattered across 4 test files. Uses bare `<-ch` (no timeout) — `go test -timeout` is the correct safety net for never-signal bugs. Verified with `-race -count=500 -timeout=150s` (107s, 0 failures).

Relates to wspulse/.github#24

## Changes

- **testhelpers_test.go** (new): generic `requireReceive[T]` — bare channel receive with `t.Helper()`.
- **hub_test.go**: 8 inline select+timeout blocks → `requireReceive`. (-57 lines)
- **session_misc_test.go**: ~14 inline select+timeout blocks → `requireReceive`. (-88 lines)
- **metrics_hook_test.go**: 4 inline select+timeout blocks → `requireReceive`. (-20 lines)
- **session_resume_test.go**: 45 inline select+timeout blocks → `requireReceive`. (-126 lines)
- 5 patterns left inline intentionally: 1 `gracePeriod` timing assertion, 1 `200ms` negative test, 3 concurrent diagnostic timeouts with counter state in `Failf`.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR
