### PR TITLE
refactor: move NewTestServer to wstest sub-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `NewTestServer` moved from the main `wspulse` package to `server/wstest` sub-package. Import path changes from `wspulse.NewTestServer(...)` to `wstest.NewTestServer(...)`. This removes `net/http/httptest` and `testing` from the production import graph.
+
+### Removed
+
+- `NewTestServer` from the main package (use `github.com/wspulse/server/wstest` instead)
+
 ---
 
 ## [0.7.0] - 2026-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **BREAKING**: `NewTestServer` moved from the main `wspulse` package to `server/wstest` sub-package. Import path changes from `wspulse.NewTestServer(...)` to `wstest.NewTestServer(...)`. This removes `net/http/httptest` and `testing` from the production import graph.
+- **BREAKING**: `NewTestServer` moved from the main `wspulse` package to `github.com/wspulse/server/wstest`. Import path changes from `wspulse.NewTestServer(...)` to `wstest.NewTestServer(...)`. This removes `net/http/httptest` and `testing` from the production import graph.
 
 ### Removed
 

--- a/wstest/server.go
+++ b/wstest/server.go
@@ -1,17 +1,23 @@
-package wspulse
+// Package wstest provides test helpers for wspulse/server.
+//
+// Import this package only in _test.go files to avoid pulling test
+// infrastructure into production binaries.
+package wstest
 
 import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	wspulse "github.com/wspulse/server"
 )
 
 // NewTestServer creates an in-process test server for use in application tests.
 // It returns the WebSocket URL (ws://...) ready for client.Dial.
 // The server and its HTTP listener are automatically cleaned up when the test ends.
-func NewTestServer(t testing.TB, connect ConnectFunc, opts ...ServerOption) string {
+func NewTestServer(t testing.TB, connect wspulse.ConnectFunc, opts ...wspulse.ServerOption) string {
 	t.Helper()
-	srv := NewServer(connect, opts...)
+	srv := wspulse.NewServer(connect, opts...)
 	ts := httptest.NewServer(srv)
 	t.Cleanup(func() {
 		srv.Close()

--- a/wstest/server_test.go
+++ b/wstest/server_test.go
@@ -1,4 +1,4 @@
-package wspulse_test
+package wstest_test
 
 import (
 	"net/http"
@@ -8,11 +8,11 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
-	wspulse "github.com/wspulse/server"
+	"github.com/wspulse/server/wstest"
 )
 
 func TestNewTestServer_ReturnsWSURL(t *testing.T) {
-	url := wspulse.NewTestServer(t, func(r *http.Request) (string, string, error) {
+	url := wstest.NewTestServer(t, func(r *http.Request) (string, string, error) {
 		return "room", "", nil
 	})
 	require.True(t, strings.HasPrefix(url, "ws://"),


### PR DESCRIPTION
## Summary

Move `NewTestServer` from the main `wspulse` package to a new `wstest/` sub-package so that `net/http/httptest` and `testing` are no longer compiled into production binaries.

## Related issues

Closes #29

## Changes

- Created `wstest/server.go` with `NewTestServer` (identical implementation, new package)
- Moved `testing_test.go` to `wstest/server_test.go` (adjusted imports)
- Deleted `testing.go` and `testing_test.go` from the main package
- Updated `CHANGELOG.md` `[Unreleased]` with breaking change and removal

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional (list only those that apply)

- [x] New public API: includes GoDoc comments
- [x] Breaking change: major version bump discussed in linked issue