### PR TITLE
refactor: change module path to github.com/wspulse/hub

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
-# Copilot Instructions — wspulse/server
+# Copilot Instructions — wspulse/hub
 
 ## Project Overview
 
-wspulse/server is a **minimal, production-ready WebSocket server library** for Go. It manages concurrent connections, room-based broadcasting, session resumption, and heartbeat. Module path: `github.com/wspulse/server`. Package name: `wspulse`. Depends on `github.com/wspulse/core` for shared types (`Frame`, `Codec`).
+wspulse/hub is a **minimal, production-ready WebSocket server library** for Go. It manages concurrent connections, room-based broadcasting, session resumption, and heartbeat. Module path: `github.com/wspulse/hub`. Package name: `wspulse`. Depends on `github.com/wspulse/core` for shared types (`Frame`, `Codec`).
 
 ## Architecture
 
@@ -29,7 +29,7 @@ make tidy             # tidy module dependencies
 
 ## Conventions
 
-- **Go style**: `gofmt`/`goimports`, snake_case filenames, GoDoc on all public symbols, `if err != nil` error handling (no runtime panics; setup-time programmer-error panics are allowed — see **Panic policy** critical rule), secrets from env vars only. Package name is `wspulse` (not `server`) — import path `github.com/wspulse/server` resolves as `wspulse.X` without an alias.
+- **Go style**: `gofmt`/`goimports`, snake_case filenames, GoDoc on all public symbols, `if err != nil` error handling (no runtime panics; setup-time programmer-error panics are allowed — see **Panic policy** critical rule), secrets from env vars only. Package name is `wspulse` (not `server`) — import path `github.com/wspulse/hub` resolves as `wspulse.X` without an alias.
 - **Naming**:
   - **Interface names** must use full words — no abbreviations. Write `Connection`, not `Conn`; `Configuration`, not `Cfg`; `Manager`, not `Mgr`.
   - **Variable and parameter names** follow standard Go style: single-letter or short receivers (`r` for `*Router`, `c` for `*Context`), idiomatic short names for local scope (`conn`, `fn`, `err`, `ok`, `n`, `i`, `v`), and descriptive names for package-level identifiers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ making any changes.
 
 ## Quick Reference
 
-**Module**: `github.com/wspulse/hub` | **Package**: `server`
+**Module**: `github.com/wspulse/hub` | **Package**: `wspulse`
 
 **Key files**:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — wspulse/server
+# AGENTS.md — wspulse/hub
 
 This file is the entry point for all AI coding agents (GitHub Copilot, Codex,
 Cursor, Claude, etc.). Full working rules are in
@@ -9,7 +9,7 @@ making any changes.
 
 ## Quick Reference
 
-**Module**: `github.com/wspulse/server` | **Package**: `server`
+**Module**: `github.com/wspulse/hub` | **Package**: `server`
 
 **Key files**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Renamed `Server` interface to `Hub`, `NewServer()` to `NewHub()`, `ServerOption` to `HubOption`
 - Renamed `ErrServerClosed` to `ErrHubClosed`, `DisconnectServerClose` to `DisconnectHubClose` (string value: `"hub_close"`)
 - Renamed internal event loop from `hub` to `heart` (`hub.go` → `heart.go`)
-- `NewTestServer` moved from the main `wspulse` package to `github.com/wspulse/server/wstest` and renamed to `NewTestHub`. Import path changes from `wspulse.NewTestServer(...)` to `wstest.NewTestHub(...)`. This removes `net/http/httptest` and `testing` from the production import graph.
+- `NewTestServer` moved from the main `wspulse` package to `github.com/wspulse/hub/wstest` and renamed to `NewTestHub`. Import path changes from `wspulse.NewTestServer(...)` to `wstest.NewTestHub(...)`. This removes `net/http/httptest` and `testing` from the production import graph.
 
 ---
 
@@ -83,7 +83,7 @@
 
 ### Changed
 
-- Package name changed from `server` to `wspulse` — import path unchanged (`github.com/wspulse/server`), but the default identifier is now `wspulse.NewServer`, `wspulse.Server`, `wspulse.Connection`, etc. Consumers using the old bare import must add an alias (`server "github.com/wspulse/server"`) or update references. (**breaking**)
+- Package name changed from `server` to `wspulse` — import path unchanged (`github.com/wspulse/hub`), but the default identifier is now `wspulse.NewServer`, `wspulse.Server`, `wspulse.Connection`, etc. Consumers using the old bare import must add an alias (`server "github.com/wspulse/hub"`) or update references. (**breaking**)
 
 ---
 
@@ -134,12 +134,12 @@
 - `Server.Close` is synchronous — returns only after all goroutines exit
 - Data race in `attachWS` buffer length check
 
-[Unreleased]: https://github.com/wspulse/server/compare/v0.7.0...HEAD
-[0.7.0]: https://github.com/wspulse/server/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/wspulse/server/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/wspulse/server/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/wspulse/server/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/wspulse/server/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/wspulse/server/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/wspulse/server/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/wspulse/server/releases/tag/v0.1.0
+[Unreleased]: https://github.com/wspulse/hub/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/wspulse/hub/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/wspulse/hub/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/wspulse/hub/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/wspulse/hub/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/wspulse/hub/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/wspulse/hub/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/wspulse/hub/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/wspulse/hub/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to wspulse/server
+# Contributing to wspulse/hub
 
 Thank you for your interest in contributing. This document describes the process and conventions expected for all contributions.
 
@@ -12,7 +12,7 @@ Thank you for your interest in contributing. This document describes the process
 ## Development Setup
 
 ```bash
-git clone https://github.com/wspulse/server
+git clone https://github.com/wspulse/hub
 cd server
 # Clone core alongside server (required for local replace directive)
 git clone https://github.com/wspulse/core ../core
@@ -57,7 +57,7 @@ All commit messages must be in English.
 
 ## API Compatibility
 
-wspulse/server follows semantic versioning. Any change that removes, renames, or alters the signature of an exported symbol is a **breaking change** and requires a major version bump.
+wspulse/hub follows semantic versioning. Any change that removes, renames, or alters the signature of an exported symbol is a **breaking change** and requires a major version bump.
 
 - Before removing a symbol, mark it `// Deprecated: use Xxx instead.` in a minor release.
 - Adding a method to an exported interface is also a breaking change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Thank you for your interest in contributing. This document describes the process
 
 ```bash
 git clone https://github.com/wspulse/hub
-cd server
-# Clone core alongside server (required for local replace directive)
+cd hub
+# Clone core alongside hub (required for local replace directive)
 git clone https://github.com/wspulse/core ../core
 go mod tidy
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# wspulse/server
+# wspulse/hub
 
-[![CI](https://github.com/wspulse/server/actions/workflows/ci.yml/badge.svg)](https://github.com/wspulse/server/actions/workflows/ci.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/wspulse/server.svg)](https://pkg.go.dev/github.com/wspulse/server)
+[![CI](https://github.com/wspulse/hub/actions/workflows/ci.yml/badge.svg)](https://github.com/wspulse/hub/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/wspulse/hub.svg)](https://pkg.go.dev/github.com/wspulse/hub)
 [![Go](https://img.shields.io/badge/Go-1.26-blue.svg?logo=go)](https://go.dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A minimal, production-ready WebSocket server for Go with room-based routing, session resumption, and pluggable codecs.
 
-**Status:** v0 — API is being stabilized. Module path: `github.com/wspulse/server`. Package name: `wspulse`.
+**Status:** v0 — API is being stabilized. Module path: `github.com/wspulse/hub`. Package name: `wspulse`.
 
 ---
 
@@ -24,7 +24,7 @@ A minimal, production-ready WebSocket server for Go with room-based routing, ses
 ## Install
 
 ```bash
-go get github.com/wspulse/server
+go get github.com/wspulse/hub
 ```
 
 ---
@@ -32,7 +32,7 @@ go get github.com/wspulse/server
 ## Quick Start
 
 ```go
-import "github.com/wspulse/server" // package name: wspulse
+import "github.com/wspulse/hub" // package name: wspulse
 
 srv := wspulse.NewHub(
     // ConnectFunc: authenticate and assign room + connection IDs
@@ -87,7 +87,7 @@ connections := srv.GetConnections(roomID)
 
 ```go
 import (
-    "github.com/wspulse/server" // package name: wspulse
+    "github.com/wspulse/hub" // package name: wspulse
     "github.com/wspulse/core/router"
 )
 
@@ -163,7 +163,7 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 
 ## Metrics
 
-wspulse/server exposes a `MetricsCollector` interface with typed hooks for connection lifecycle, room state, throughput, backpressure, and heartbeat health. The default is `NoopCollector{}` (minimal overhead). Embed `NoopCollector` in custom implementations for forward-compatible additions.
+wspulse/hub exposes a `MetricsCollector` interface with typed hooks for connection lifecycle, room state, throughput, backpressure, and heartbeat health. The default is `NoopCollector{}` (minimal overhead). Embed `NoopCollector` in custom implementations for forward-compatible additions.
 
 ```go
 // Use a contrib adapter (e.g. wspulse/metrics-prometheus or wspulse/metrics-otel),
@@ -205,7 +205,7 @@ The value of `"event"` is `frame.Event` on the Go side, and is the key used to s
 
 ```go
 import (
-    "github.com/wspulse/server" // package name: wspulse
+    "github.com/wspulse/hub" // package name: wspulse
     "github.com/wspulse/core/router"
 )
 

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -1,9 +1,9 @@
-# wspulse/server — Transport Layer Internals
+# wspulse/hub — Transport Layer Internals
 
-This document describes the internal implementation mechanisms of wspulse/server
+This document describes the internal implementation mechanisms of wspulse/hub
 at the **transport and infrastructure layer**. Application-level semantics
 (business logic, room state, message history) are out of scope here; those
-belong to the consumers of wspulse/server.
+belong to the consumers of wspulse/hub.
 
 ---
 
@@ -150,7 +150,7 @@ explicit `Hub.Kick` call) initiates the teardown.
 
 ## 5. Session Resumption
 
-When `WithResumeWindow(d)` is configured with `d > 0`, wspulse/server
+When `WithResumeWindow(d)` is configured with `d > 0`, wspulse/hub
 introduces a **session layer** that decouples the application-visible
 `Connection` from the underlying WebSocket transport. This allows transparent
 reconnection without leaking connect/disconnect events to the application
@@ -269,7 +269,7 @@ If the heart has already shut down (`<-heart.done`), `Kick` returns
 
 ## 6. Metrics
 
-wspulse/server exposes an optional `MetricsCollector` interface for
+wspulse/hub exposes an optional `MetricsCollector` interface for
 instrumentation. The default is `NoopCollector{}`, a no-op implementation
 that discards all events with minimal overhead.
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wspulse/server
+module github.com/wspulse/hub
 
 go 1.26.0
 

--- a/heart_test.go
+++ b/heart_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/metrics_hook_test.go
+++ b/metrics_hook_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 // ── recordingCollector helpers (moved from metrics_integration_test.go) ──────

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 // ── NoopCollector ─────────────────────────────────────────────────────────────

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 // benchAcceptN returns a ConnectFunc that assigns each connection to

--- a/server_test.go
+++ b/server_test.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/goleak"
 	"go.uber.org/zap/zaptest"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 func acceptAll(r *http.Request) (roomID, connectionID string, err error) {

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 // ── ReadPump panic recovery ─────────────────────────────────────────────────

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/wstest/server.go
+++ b/wstest/server.go
@@ -1,4 +1,4 @@
-// Package wstest provides test helpers for wspulse/server.
+// Package wstest provides test helpers for wspulse/hub.
 //
 // Import this package only in _test.go files to avoid pulling test
 // infrastructure into production binaries.
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	wspulse "github.com/wspulse/server"
+	wspulse "github.com/wspulse/hub"
 )
 
 // NewTestHub creates an in-process test server for use in application tests.

--- a/wstest/server_test.go
+++ b/wstest/server_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wspulse/server/wstest"
+	"github.com/wspulse/hub/wstest"
 )
 
 func TestNewTestHub_ReturnsWSURL(t *testing.T) {


### PR DESCRIPTION
## Summary

Update Go module path from `github.com/wspulse/server` to `github.com/wspulse/hub` after the GitHub repo rename.

## Related issues

Relates to wspulse/.github#23

## Changes

- `go.mod`: module path `github.com/wspulse/server` → `github.com/wspulse/hub`
- All `.go` import statements updated
- All documentation references updated (README, AGENTS, CONTRIBUTING, copilot-instructions, internals, CHANGELOG)

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: module path change discussed in linked issue (wspulse/.github#23)