### PR TITLE
fix: default pingInterval 20s + validate pingInterval > writeTimeout in NewHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Default `pingInterval` changed from 10 s to 20 s to satisfy the constraint
+  that `pingInterval` must be strictly greater than `writeTimeout` (default 10 s).
+
+### Fixed
+
+- `NewHub` now panics at construction time if `pingInterval <= writeTimeout`
+  after all options are applied. Previously this misconfiguration was silently
+  accepted, causing the `pingPump` ticker to fire while a pong was still pending
+  and compressing the effective heartbeat interval to the pong latency.
+
 ## [0.9.1] - 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ go get github.com/wspulse/hub
 ```go
 import "github.com/wspulse/hub" // package name: wspulse
 
-srv := wspulse.NewHub(
+var srv wspulse.Hub
+srv = wspulse.NewHub(
     // ConnectFunc: authenticate and assign room + connection IDs
     func(r *http.Request) (roomID, connectionID string, err error) {
         token := r.URL.Query().Get("token")

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ srv := wspulse.NewHub(
     wspulse.WithOnDisconnect(func(connection wspulse.Connection, err error) {
         log.Printf("disconnected: %s", connection.ID())
     }),
-    wspulse.WithPingInterval(10*time.Second),
+    wspulse.WithPingInterval(30*time.Second),
     wspulse.WithResumeWindow(30*time.Second),
 )
 
@@ -136,7 +136,7 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | `WithOnTransportDrop(fn)`   | —                                    |
 | `WithOnTransportRestore(fn)`| —                                    |
 | `WithResumeWindow(d)`        | 0 (disabled)                         |
-| `WithPingInterval(d)`       | 10 s                                 |
+| `WithPingInterval(d)`       | 20 s                                 |
 | `WithWriteTimeout(d)`       | 10 s                                 |
 | `WithMaxMessageSize(n)`     | 512 B                                |
 | `WithSendBufferSize(n)`     | 256 frames                           |

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -85,7 +85,7 @@ arrives or the context expires.
 | `pingInterval`   | 20 s    | (writeTimeout, 1 m]  | `pingPump` ticker interval; one synchronous Ping sent per tick        |
 | `writeTimeout`   | 10 s    | (0, 30 s]            | Per-write deadline and Ping timeout (context timeout for `Ping(ctx)`) |
 | `maxMessageSize` | 512 B   | [1, 64 MiB]          | `readPump SetReadLimit`; exceeded size triggers immediate disconnect   |
-| Send buffer      | 256     | [1, 4096]            | `session.send` channel depth (configurable via `WithSendBufferSize`)  |
+| Send buffer      | 256     | [1, 4096]            | `session.send` queue capacity (configurable via `WithSendBufferSize`) |
 
 **Constraint:** `pingInterval` must be strictly greater than `writeTimeout`.
 `NewHub` panics at construction time if this constraint is violated.

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -256,7 +256,7 @@ The total time a client has to reconnect is:
 effective window = pingInterval + writeTimeout + resumeWindow
 ```
 
-- `pingInterval` (default 10 s): worst-case wait until the next ping fires.
+- `pingInterval` (default 20 s): worst-case wait until the next ping fires.
 - `writeTimeout` (default 10 s): Ping timeout before the server detects the dead
   transport.
 - `resumeWindow` (configured via `WithResumeWindow`): additional grace period

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -80,12 +80,17 @@ arrives or the context expires.
 
 ### Parameters
 
-| Parameter        | Default | Valid range | Description                                                             |
-| ---------------- | ------- | ----------- | ----------------------------------------------------------------------- |
-| `pingInterval`   | 10 s    | (0, 1 m]    | `pingPump` ticker interval; one synchronous Ping sent per tick          |
-| `writeTimeout`      | 10 s    | (0, 30 s]   | Per-write deadline and Ping timeout (context timeout for `Ping(ctx)`)   |
-| `maxMessageSize` | 512 B   | [1, 64 MiB] | `readPump SetReadLimit`; exceeded size triggers immediate disconnect    |
-| Send buffer      | 256     | [1, 4096]   | `session.send` channel depth (configurable via `WithSendBufferSize`)    |
+| Parameter        | Default | Valid range          | Description                                                           |
+| ---------------- | ------- | -------------------- | --------------------------------------------------------------------- |
+| `pingInterval`   | 20 s    | (writeTimeout, 1 m]  | `pingPump` ticker interval; one synchronous Ping sent per tick        |
+| `writeTimeout`   | 10 s    | (0, 30 s]            | Per-write deadline and Ping timeout (context timeout for `Ping(ctx)`) |
+| `maxMessageSize` | 512 B   | [1, 64 MiB]          | `readPump SetReadLimit`; exceeded size triggers immediate disconnect   |
+| Send buffer      | 256     | [1, 4096]            | `session.send` channel depth (configurable via `WithSendBufferSize`)  |
+
+**Constraint:** `pingInterval` must be strictly greater than `writeTimeout`.
+`NewHub` panics at construction time if this constraint is violated.
+This ensures the Pong for ping N always resolves before the ticker fires for ping N+1
+on a healthy connection, preventing tick accumulation in the `pingPump` select loop.
 
 Configuring non-default values:
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,17 @@
 package wspulse
 
-import core "github.com/wspulse/core"
+import (
+	"net/http"
+
+	core "github.com/wspulse/core"
+)
+
+// DefaultPingInterval and DefaultWriteTimeout expose the default configuration
+// values so external test packages can verify the constraint pingInterval > writeTimeout.
+var (
+	DefaultPingInterval = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).pingInterval
+	DefaultWriteTimeout = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).writeTimeout
+)
 
 // Clock exports the internal clock interface for testing only.
 type Clock = clock

--- a/export_test.go
+++ b/export_test.go
@@ -2,16 +2,22 @@ package wspulse
 
 import (
 	"net/http"
+	"time"
 
 	core "github.com/wspulse/core"
 )
 
-// DefaultPingInterval and DefaultWriteTimeout expose the default configuration
-// values so external test packages can verify the constraint pingInterval > writeTimeout.
-var (
-	DefaultPingInterval = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).pingInterval
-	DefaultWriteTimeout = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).writeTimeout
-)
+// DefaultPingInterval returns the default pingInterval from defaultConfig.
+// Exposed as a function (not a var) so external test packages cannot mutate it.
+func DefaultPingInterval() time.Duration {
+	return defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).pingInterval
+}
+
+// DefaultWriteTimeout returns the default writeTimeout from defaultConfig.
+// Exposed as a function (not a var) so external test packages cannot mutate it.
+func DefaultWriteTimeout() time.Duration {
+	return defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).writeTimeout
+}
 
 // Clock exports the internal clock interface for testing only.
 type Clock = clock

--- a/metrics_hook_test.go
+++ b/metrics_hook_test.go
@@ -280,6 +280,7 @@ func TestMetricsCollector_PongTimeout(t *testing.T) {
 		},
 		wspulse.WithMetrics(rec),
 		wspulse.WithPingInterval(50*time.Millisecond),
+		wspulse.WithWriteTimeout(25*time.Millisecond),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			connected <- struct{}{}
 		}),

--- a/options.go
+++ b/options.go
@@ -131,8 +131,8 @@ func WithOnTransportRestore(fn func(Connection)) HubOption {
 
 // WithPingInterval sets the interval between heartbeat pings sent by the
 // hub's pingPump goroutine. Each ping uses a synchronous Ping(ctx) call with
-// a timeout derived from WriteTimeout. If the pong does not arrive within that
-// timeout, the connection is considered dead.
+// a timeout equal to writeTimeout (configured via WithWriteTimeout). If the
+// pong does not arrive within that timeout, the connection is considered dead.
 // d must be in (writeTimeout, 1m]. Default: 20 s.
 // NewHub panics if pingInterval <= writeTimeout after all options are applied.
 func WithPingInterval(d time.Duration) HubOption {

--- a/options.go
+++ b/options.go
@@ -54,7 +54,7 @@ type hubConfig struct {
 func defaultConfig(connect ConnectFunc) *hubConfig {
 	return &hubConfig{
 		connect:        connect,
-		pingInterval:   10 * time.Second,
+		pingInterval:   20 * time.Second,
 		writeTimeout:   10 * time.Second,
 		maxMessageSize: 512,
 		sendBufferSize: 256,
@@ -133,7 +133,8 @@ func WithOnTransportRestore(fn func(Connection)) HubOption {
 // hub's pingPump goroutine. Each ping uses a synchronous Ping(ctx) call with
 // a timeout derived from WriteTimeout. If the pong does not arrive within that
 // timeout, the connection is considered dead.
-// d must be in (0, 1m]. Default: 10 s.
+// d must be in (writeTimeout, 1m]. Default: 20 s.
+// NewHub panics if pingInterval <= writeTimeout after all options are applied.
 func WithPingInterval(d time.Duration) HubOption {
 	if d <= 0 {
 		panic("wspulse: WithPingInterval: duration must be positive")

--- a/server.go
+++ b/server.go
@@ -48,6 +48,7 @@ type internalHub struct {
 var _ Hub = (*internalHub)(nil)
 
 // NewHub creates and starts a Hub. connect must not be nil.
+// Panics if pingInterval <= writeTimeout after all options are applied.
 func NewHub(connect ConnectFunc, options ...HubOption) Hub {
 	if connect == nil {
 		panic("wspulse: NewHub: connect must not be nil")
@@ -55,6 +56,9 @@ func NewHub(connect ConnectFunc, options ...HubOption) Hub {
 	config := defaultConfig(connect)
 	for _, option := range options {
 		option(config)
+	}
+	if config.pingInterval <= config.writeTimeout {
+		panic("wspulse: NewHub: pingInterval must be greater than writeTimeout")
 	}
 	h := newHeart(config)
 	heartDone := make(chan struct{})

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -627,6 +627,28 @@ func TestWithPingInterval_ExceedsMaxPanics(t *testing.T) {
 	})
 }
 
+func TestNewHub_PanicsWhenPingIntervalEqualToWriteTimeout(t *testing.T) {
+	t.Parallel()
+	require.PanicsWithValue(t,
+		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
+		func() {
+			// writeTimeout default is 10s; set pingInterval == writeTimeout.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(10*time.Second))
+		},
+	)
+}
+
+func TestNewHub_PanicsWhenPingIntervalLessThanWriteTimeout(t *testing.T) {
+	t.Parallel()
+	require.PanicsWithValue(t,
+		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
+		func() {
+			// writeTimeout default is 10s; set pingInterval < writeTimeout.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(5*time.Second))
+		},
+	)
+}
+
 // ── HubShutdown ReadPump inline cleanup ─────────────────────────────────────
 
 func TestHubShutdown_ReadPumpInlineCleanup(t *testing.T) {

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -594,7 +594,7 @@ func TestCloseWhileConnecting_NoLeak(t *testing.T) {
 
 func TestDefaultConfigSatisfiesPingIntervalConstraint(t *testing.T) {
 	t.Parallel()
-	require.Greater(t, wspulse.DefaultPingInterval, wspulse.DefaultWriteTimeout,
+	require.Greater(t, wspulse.DefaultPingInterval(), wspulse.DefaultWriteTimeout(),
 		"default pingInterval must be strictly greater than default writeTimeout")
 }
 
@@ -632,8 +632,8 @@ func TestNewHub_PanicsWhenPingIntervalEqualToWriteTimeout(t *testing.T) {
 	require.PanicsWithValue(t,
 		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
 		func() {
-			// writeTimeout default is 10s; set pingInterval == writeTimeout.
-			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(10*time.Second))
+			// pingInterval == default writeTimeout → must panic.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(wspulse.DefaultWriteTimeout()))
 		},
 	)
 }
@@ -643,8 +643,8 @@ func TestNewHub_PanicsWhenPingIntervalLessThanWriteTimeout(t *testing.T) {
 	require.PanicsWithValue(t,
 		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
 		func() {
-			// writeTimeout default is 10s; set pingInterval < writeTimeout.
-			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(5*time.Second))
+			// pingInterval < default writeTimeout → must panic.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(wspulse.DefaultWriteTimeout()/2))
 		},
 	)
 }

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -592,6 +592,12 @@ func TestCloseWhileConnecting_NoLeak(t *testing.T) {
 
 // ── WithPingInterval ───────────────────────────────────────────────────────
 
+func TestDefaultConfigSatisfiesPingIntervalConstraint(t *testing.T) {
+	t.Parallel()
+	require.Greater(t, wspulse.DefaultPingInterval, wspulse.DefaultWriteTimeout,
+		"default pingInterval must be strictly greater than default writeTimeout")
+}
+
 func TestWithPingInterval_Valid(t *testing.T) {
 	t.Parallel()
 	require.NotPanics(t, func() {

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -930,7 +930,7 @@ func TestResume_WritePumpExitsViaContextCancellation(t *testing.T) {
 	srv := wspulse.NewHub(
 		acceptAll,
 		wspulse.WithResumeWindow(5*time.Second),
-		wspulse.WithPingInterval(5*time.Second), // long ping interval; writeTimeout default is 1s below
+		wspulse.WithPingInterval(5*time.Second), // long ping interval; writeTimeout explicitly set to 1s below
 		wspulse.WithWriteTimeout(1*time.Second),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			select {

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -930,7 +930,8 @@ func TestResume_WritePumpExitsViaContextCancellation(t *testing.T) {
 	srv := wspulse.NewHub(
 		acceptAll,
 		wspulse.WithResumeWindow(5*time.Second),
-		wspulse.WithPingInterval(5*time.Second), // long ping interval
+		wspulse.WithPingInterval(5*time.Second), // long ping interval; writeTimeout default is 1s below
+		wspulse.WithWriteTimeout(1*time.Second),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			select {
 			case connected <- struct{}{}:


### PR DESCRIPTION
## Summary

`pingPump` uses a synchronous `Ping(ctx)` call; when `pingInterval <= writeTimeout` the ticker can fire while a Pong is still pending, collapsing effective ping cadence to pong latency. This PR raises the default `pingInterval` to 20 s (was 10 s, equal to `writeTimeout`) and adds a construction-time panic to catch any misconfiguration.

## Related issues

Closes #49
Relates to wspulse/.github#39

## Changes

- `options.go`: `defaultConfig()` `pingInterval` changed from 10 s to 20 s
- `options.go`: `WithPingInterval` GoDoc documents the `> writeTimeout` constraint
- `server.go` (`NewHub`): panics with `"wspulse: NewHub: pingInterval must be greater than writeTimeout"` if the constraint is violated after all options are applied
- `server.go` (`NewHub`): GoDoc updated to document the cross-constraint panic
- `export_test.go`: exports `DefaultPingInterval` and `DefaultWriteTimeout` for external test access
- `session_misc_test.go`: adds three tests — default satisfies constraint, equal case panics, less-than case panics
- Fixed two existing tests that used `WithPingInterval` values that would now violate the constraint (`metrics_hook_test.go`, `session_resume_test.go`)
- `doc/internals.md`: heartbeat table updated (default 20 s, valid range `(writeTimeout, 1m]`), constraint paragraph added
- `CHANGELOG.md`: `[Unreleased]` entries for the default change and the new panic

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Bug fix: includes a test that fails before the fix and passes after
- [x] New public API: includes GoDoc comments
- [x] Heart serialization not violated (no session state mutation outside heart goroutine)