### PR TITLE
release: v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-04-15
+
 ### Changed
 
 - Default `pingInterval` changed from 10 s to 20 s to satisfy the constraint
@@ -169,7 +171,8 @@
 - `Server.Close` is synchronous — returns only after all goroutines exit
 - Data race in `attachWS` buffer length check
 
-[Unreleased]: https://github.com/wspulse/hub/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/wspulse/hub/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/wspulse/hub/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/wspulse/hub/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/wspulse/hub/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/wspulse/hub/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@
 - Heartbeat mechanism: writePump no longer drives Ping; a dedicated `pingPump` goroutine uses `coder/websocket`'s synchronous `Ping(ctx)` API
 - TCP drops now propagate the actual I/O error to `OnDisconnect`/`OnTransportDrop` callbacks. Previously, gorilla wrapped TCP drops as close code 1006 which was classified as normal (nil error). This does not affect the suspend-vs-disconnect decision — that is determined solely by `resumeWindow`
 
----
 
 ## [0.8.0] - 2026-04-09
 
@@ -42,7 +41,6 @@
 - Renamed internal event loop from `hub` to `heart` (`hub.go` → `heart.go`)
 - `NewTestServer` moved from the main `wspulse` package to `github.com/wspulse/hub/wstest` and renamed to `NewTestHub`. Import path changes from `wspulse.NewTestServer(...)` to `wstest.NewTestHub(...)`. This removes `net/http/httptest` and `testing` from the production import graph.
 
----
 
 ## [0.7.0] - 2026-04-08
 
@@ -61,7 +59,6 @@
 - Fix race between `Close()` and `handleTransportDied` where `Close()` sets `stateClosed` before `detachWS()` runs, causing `OnDisconnect` to never fire. The hub now calls `disconnectSession` when `detachWS` detects a concurrently-closed session.
 - Fix `ResumeAttempt` metric firing after `attachWS` goroutine spawn, creating a window where the recording is not visible to the test's synchronous assertion. Moved metric call before `attachWS`.
 
----
 
 ## [0.6.0] - 2026-03-27
 
@@ -73,7 +70,6 @@
   always `true` — resume success rate is derivable from existing metrics
   (`ResumeAttempt` count vs `ConnectionClosed` with grace-expired reason).
 
----
 
 ## [0.5.0] - 2026-03-25
 
@@ -108,7 +104,6 @@
 
 - `WithResumeWindow` no longer enforces a 3-minute upper bound — any non-negative `time.Duration` is accepted
 
----
 
 ## [0.3.0] - 2026-03-13
 
@@ -116,7 +111,6 @@
 
 - Package name changed from `server` to `wspulse` — import path unchanged (`github.com/wspulse/hub`), but the default identifier is now `wspulse.NewServer`, `wspulse.Server`, `wspulse.Connection`, etc. Consumers using the old bare import must add an alias (`server "github.com/wspulse/hub"`) or update references. (**breaking**)
 
----
 
 ## [0.2.1] - 2026-03-12
 
@@ -124,7 +118,6 @@
 
 - `WithResumeWindow` parameter changed from `int` (seconds) to `time.Duration` — e.g. `WithResumeWindow(30 * time.Second)` (**breaking**)
 
----
 
 ## [0.2.0] - 2026-03-12
 
@@ -141,7 +134,6 @@
 - `handleRegister` no longer silently drops `OnDisconnect` when a reconnect races a `Connection.Close()` on a suspended session
 - `disconnectSession` now cancels the grace timer before calling `Close()`, preventing a spurious `graceExpiredMessage` from being enqueued on the hub channel
 
----
 
 ## [0.1.0] - 2026-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Default `pingInterval` changed from 10 s to 20 s to satisfy the constraint
+  that `pingInterval` must be strictly greater than `writeTimeout` (default 10 s).
+
+### Fixed
+
+- `NewHub` now panics at construction time if `pingInterval <= writeTimeout`
+  after all options are applied. Previously this misconfiguration was silently
+  accepted, causing the `pingPump` ticker to fire while a pong was still pending
+  and compressing the effective heartbeat interval to the pong latency.
+
 ## [0.9.1] - 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ go get github.com/wspulse/hub
 ```go
 import "github.com/wspulse/hub" // package name: wspulse
 
-srv := wspulse.NewHub(
+var srv wspulse.Hub
+srv = wspulse.NewHub(
     // ConnectFunc: authenticate and assign room + connection IDs
     func(r *http.Request) (roomID, connectionID string, err error) {
         token := r.URL.Query().Get("token")

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ srv := wspulse.NewHub(
     wspulse.WithOnDisconnect(func(connection wspulse.Connection, err error) {
         log.Printf("disconnected: %s", connection.ID())
     }),
-    wspulse.WithPingInterval(10*time.Second),
+    wspulse.WithPingInterval(30*time.Second),
     wspulse.WithResumeWindow(30*time.Second),
 )
 
@@ -136,7 +136,7 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | `WithOnTransportDrop(fn)`   | —                                    |
 | `WithOnTransportRestore(fn)`| —                                    |
 | `WithResumeWindow(d)`        | 0 (disabled)                         |
-| `WithPingInterval(d)`       | 10 s                                 |
+| `WithPingInterval(d)`       | 20 s                                 |
 | `WithWriteTimeout(d)`       | 10 s                                 |
 | `WithMaxMessageSize(n)`     | 512 B                                |
 | `WithSendBufferSize(n)`     | 256 frames                           |

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -85,7 +85,7 @@ arrives or the context expires.
 | `pingInterval`   | 20 s    | (writeTimeout, 1 m]  | `pingPump` ticker interval; one synchronous Ping sent per tick        |
 | `writeTimeout`   | 10 s    | (0, 30 s]            | Per-write deadline and Ping timeout (context timeout for `Ping(ctx)`) |
 | `maxMessageSize` | 512 B   | [1, 64 MiB]          | `readPump SetReadLimit`; exceeded size triggers immediate disconnect   |
-| Send buffer      | 256     | [1, 4096]            | `session.send` channel depth (configurable via `WithSendBufferSize`)  |
+| Send buffer      | 256     | [1, 4096]            | `session.send` queue capacity (configurable via `WithSendBufferSize`) |
 
 **Constraint:** `pingInterval` must be strictly greater than `writeTimeout`.
 `NewHub` panics at construction time if this constraint is violated.

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -256,7 +256,7 @@ The total time a client has to reconnect is:
 effective window = pingInterval + writeTimeout + resumeWindow
 ```
 
-- `pingInterval` (default 10 s): worst-case wait until the next ping fires.
+- `pingInterval` (default 20 s): worst-case wait until the next ping fires.
 - `writeTimeout` (default 10 s): Ping timeout before the server detects the dead
   transport.
 - `resumeWindow` (configured via `WithResumeWindow`): additional grace period

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -80,12 +80,17 @@ arrives or the context expires.
 
 ### Parameters
 
-| Parameter        | Default | Valid range | Description                                                             |
-| ---------------- | ------- | ----------- | ----------------------------------------------------------------------- |
-| `pingInterval`   | 10 s    | (0, 1 m]    | `pingPump` ticker interval; one synchronous Ping sent per tick          |
-| `writeTimeout`      | 10 s    | (0, 30 s]   | Per-write deadline and Ping timeout (context timeout for `Ping(ctx)`)   |
-| `maxMessageSize` | 512 B   | [1, 64 MiB] | `readPump SetReadLimit`; exceeded size triggers immediate disconnect    |
-| Send buffer      | 256     | [1, 4096]   | `session.send` channel depth (configurable via `WithSendBufferSize`)    |
+| Parameter        | Default | Valid range          | Description                                                           |
+| ---------------- | ------- | -------------------- | --------------------------------------------------------------------- |
+| `pingInterval`   | 20 s    | (writeTimeout, 1 m]  | `pingPump` ticker interval; one synchronous Ping sent per tick        |
+| `writeTimeout`   | 10 s    | (0, 30 s]            | Per-write deadline and Ping timeout (context timeout for `Ping(ctx)`) |
+| `maxMessageSize` | 512 B   | [1, 64 MiB]          | `readPump SetReadLimit`; exceeded size triggers immediate disconnect   |
+| Send buffer      | 256     | [1, 4096]            | `session.send` channel depth (configurable via `WithSendBufferSize`)  |
+
+**Constraint:** `pingInterval` must be strictly greater than `writeTimeout`.
+`NewHub` panics at construction time if this constraint is violated.
+This ensures the Pong for ping N always resolves before the ticker fires for ping N+1
+on a healthy connection, preventing tick accumulation in the `pingPump` select loop.
 
 Configuring non-default values:
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,17 @@
 package wspulse
 
-import core "github.com/wspulse/core"
+import (
+	"net/http"
+
+	core "github.com/wspulse/core"
+)
+
+// DefaultPingInterval and DefaultWriteTimeout expose the default configuration
+// values so external test packages can verify the constraint pingInterval > writeTimeout.
+var (
+	DefaultPingInterval = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).pingInterval
+	DefaultWriteTimeout = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).writeTimeout
+)
 
 // Clock exports the internal clock interface for testing only.
 type Clock = clock

--- a/export_test.go
+++ b/export_test.go
@@ -2,16 +2,22 @@ package wspulse
 
 import (
 	"net/http"
+	"time"
 
 	core "github.com/wspulse/core"
 )
 
-// DefaultPingInterval and DefaultWriteTimeout expose the default configuration
-// values so external test packages can verify the constraint pingInterval > writeTimeout.
-var (
-	DefaultPingInterval = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).pingInterval
-	DefaultWriteTimeout = defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).writeTimeout
-)
+// DefaultPingInterval returns the default pingInterval from defaultConfig.
+// Exposed as a function (not a var) so external test packages cannot mutate it.
+func DefaultPingInterval() time.Duration {
+	return defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).pingInterval
+}
+
+// DefaultWriteTimeout returns the default writeTimeout from defaultConfig.
+// Exposed as a function (not a var) so external test packages cannot mutate it.
+func DefaultWriteTimeout() time.Duration {
+	return defaultConfig(func(*http.Request) (string, string, error) { return "", "", nil }).writeTimeout
+}
 
 // Clock exports the internal clock interface for testing only.
 type Clock = clock

--- a/metrics_hook_test.go
+++ b/metrics_hook_test.go
@@ -280,6 +280,7 @@ func TestMetricsCollector_PongTimeout(t *testing.T) {
 		},
 		wspulse.WithMetrics(rec),
 		wspulse.WithPingInterval(50*time.Millisecond),
+		wspulse.WithWriteTimeout(25*time.Millisecond),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			connected <- struct{}{}
 		}),

--- a/options.go
+++ b/options.go
@@ -147,6 +147,7 @@ func WithPingInterval(d time.Duration) HubOption {
 
 // WithWriteTimeout sets the timeout for a single write operation on a
 // connection, including Ping. d must be in (0, 30s]. Default: 10 s.
+// NewHub panics if writeTimeout >= pingInterval after all options are applied.
 func WithWriteTimeout(d time.Duration) HubOption {
 	if d <= 0 {
 		panic("wspulse: WithWriteTimeout: duration must be positive")

--- a/options.go
+++ b/options.go
@@ -131,8 +131,8 @@ func WithOnTransportRestore(fn func(Connection)) HubOption {
 
 // WithPingInterval sets the interval between heartbeat pings sent by the
 // hub's pingPump goroutine. Each ping uses a synchronous Ping(ctx) call with
-// a timeout derived from WriteTimeout. If the pong does not arrive within that
-// timeout, the connection is considered dead.
+// a timeout equal to writeTimeout (configured via WithWriteTimeout). If the
+// pong does not arrive within that timeout, the connection is considered dead.
 // d must be in (writeTimeout, 1m]. Default: 20 s.
 // NewHub panics if pingInterval <= writeTimeout after all options are applied.
 func WithPingInterval(d time.Duration) HubOption {

--- a/options.go
+++ b/options.go
@@ -54,7 +54,7 @@ type hubConfig struct {
 func defaultConfig(connect ConnectFunc) *hubConfig {
 	return &hubConfig{
 		connect:        connect,
-		pingInterval:   10 * time.Second,
+		pingInterval:   20 * time.Second,
 		writeTimeout:   10 * time.Second,
 		maxMessageSize: 512,
 		sendBufferSize: 256,
@@ -133,7 +133,8 @@ func WithOnTransportRestore(fn func(Connection)) HubOption {
 // hub's pingPump goroutine. Each ping uses a synchronous Ping(ctx) call with
 // a timeout derived from WriteTimeout. If the pong does not arrive within that
 // timeout, the connection is considered dead.
-// d must be in (0, 1m]. Default: 10 s.
+// d must be in (writeTimeout, 1m]. Default: 20 s.
+// NewHub panics if pingInterval <= writeTimeout after all options are applied.
 func WithPingInterval(d time.Duration) HubOption {
 	if d <= 0 {
 		panic("wspulse: WithPingInterval: duration must be positive")

--- a/server.go
+++ b/server.go
@@ -48,6 +48,7 @@ type internalHub struct {
 var _ Hub = (*internalHub)(nil)
 
 // NewHub creates and starts a Hub. connect must not be nil.
+// Panics if pingInterval <= writeTimeout after all options are applied.
 func NewHub(connect ConnectFunc, options ...HubOption) Hub {
 	if connect == nil {
 		panic("wspulse: NewHub: connect must not be nil")
@@ -55,6 +56,9 @@ func NewHub(connect ConnectFunc, options ...HubOption) Hub {
 	config := defaultConfig(connect)
 	for _, option := range options {
 		option(config)
+	}
+	if config.pingInterval <= config.writeTimeout {
+		panic("wspulse: NewHub: pingInterval must be greater than writeTimeout")
 	}
 	h := newHeart(config)
 	heartDone := make(chan struct{})

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -627,6 +627,28 @@ func TestWithPingInterval_ExceedsMaxPanics(t *testing.T) {
 	})
 }
 
+func TestNewHub_PanicsWhenPingIntervalEqualToWriteTimeout(t *testing.T) {
+	t.Parallel()
+	require.PanicsWithValue(t,
+		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
+		func() {
+			// writeTimeout default is 10s; set pingInterval == writeTimeout.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(10*time.Second))
+		},
+	)
+}
+
+func TestNewHub_PanicsWhenPingIntervalLessThanWriteTimeout(t *testing.T) {
+	t.Parallel()
+	require.PanicsWithValue(t,
+		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
+		func() {
+			// writeTimeout default is 10s; set pingInterval < writeTimeout.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(5*time.Second))
+		},
+	)
+}
+
 // ── HubShutdown ReadPump inline cleanup ─────────────────────────────────────
 
 func TestHubShutdown_ReadPumpInlineCleanup(t *testing.T) {

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -594,7 +594,7 @@ func TestCloseWhileConnecting_NoLeak(t *testing.T) {
 
 func TestDefaultConfigSatisfiesPingIntervalConstraint(t *testing.T) {
 	t.Parallel()
-	require.Greater(t, wspulse.DefaultPingInterval, wspulse.DefaultWriteTimeout,
+	require.Greater(t, wspulse.DefaultPingInterval(), wspulse.DefaultWriteTimeout(),
 		"default pingInterval must be strictly greater than default writeTimeout")
 }
 
@@ -632,8 +632,8 @@ func TestNewHub_PanicsWhenPingIntervalEqualToWriteTimeout(t *testing.T) {
 	require.PanicsWithValue(t,
 		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
 		func() {
-			// writeTimeout default is 10s; set pingInterval == writeTimeout.
-			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(10*time.Second))
+			// pingInterval == default writeTimeout → must panic.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(wspulse.DefaultWriteTimeout()))
 		},
 	)
 }
@@ -643,8 +643,8 @@ func TestNewHub_PanicsWhenPingIntervalLessThanWriteTimeout(t *testing.T) {
 	require.PanicsWithValue(t,
 		"wspulse: NewHub: pingInterval must be greater than writeTimeout",
 		func() {
-			// writeTimeout default is 10s; set pingInterval < writeTimeout.
-			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(5*time.Second))
+			// pingInterval < default writeTimeout → must panic.
+			wspulse.NewHub(acceptAll, wspulse.WithPingInterval(wspulse.DefaultWriteTimeout()/2))
 		},
 	)
 }

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -592,6 +592,12 @@ func TestCloseWhileConnecting_NoLeak(t *testing.T) {
 
 // ── WithPingInterval ───────────────────────────────────────────────────────
 
+func TestDefaultConfigSatisfiesPingIntervalConstraint(t *testing.T) {
+	t.Parallel()
+	require.Greater(t, wspulse.DefaultPingInterval, wspulse.DefaultWriteTimeout,
+		"default pingInterval must be strictly greater than default writeTimeout")
+}
+
 func TestWithPingInterval_Valid(t *testing.T) {
 	t.Parallel()
 	require.NotPanics(t, func() {

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -930,7 +930,7 @@ func TestResume_WritePumpExitsViaContextCancellation(t *testing.T) {
 	srv := wspulse.NewHub(
 		acceptAll,
 		wspulse.WithResumeWindow(5*time.Second),
-		wspulse.WithPingInterval(5*time.Second), // long ping interval; writeTimeout default is 1s below
+		wspulse.WithPingInterval(5*time.Second), // long ping interval; writeTimeout explicitly set to 1s below
 		wspulse.WithWriteTimeout(1*time.Second),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			select {

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -930,7 +930,8 @@ func TestResume_WritePumpExitsViaContextCancellation(t *testing.T) {
 	srv := wspulse.NewHub(
 		acceptAll,
 		wspulse.WithResumeWindow(5*time.Second),
-		wspulse.WithPingInterval(5*time.Second), // long ping interval
+		wspulse.WithPingInterval(5*time.Second), // long ping interval; writeTimeout default is 1s below
+		wspulse.WithWriteTimeout(1*time.Second),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			select {
 			case connected <- struct{}{}:


### PR DESCRIPTION
## Summary

Release v0.9.2 — fixes the `pingInterval <= writeTimeout` misconfiguration bug that caused heartbeat tick accumulation in `pingPump`.

## Changes

- Default `pingInterval` raised from 10 s to 20 s (was equal to `writeTimeout`, leaving zero margin)
- `NewHub` panics at construction time if `pingInterval <= writeTimeout` after all options are applied
- `WithPingInterval` GoDoc updated to document the cross-constraint requirement
- `export_test.go` accessors changed from vars to functions (`DefaultPingInterval()` / `DefaultWriteTimeout()`) to prevent mutation in parallel tests
- `doc/internals.md`, `README.md`, and `CHANGELOG.md` updated to reflect new defaults and constraint

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Bug fix: includes a test that fails before the fix and passes after
- [x] New public API: includes GoDoc comments
- [x] Heart serialization not violated (no session state mutation outside heart goroutine)