### PR TITLE
release: v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-04-16
+
+### Changed
+
+- Replaced `core.Transport` with a hub-local unexported `transport` interface.
+  The hub now owns its transport contract independently of the shared core module.
+  No public API change — the transport type was internal-only.
+- Upgraded `github.com/wspulse/core` from v0.4.0 to v0.5.0 (which removed the
+  shared `Transport` interface).
+
 ## [0.9.2] - 2026-04-15
 
 ### Changed
@@ -171,7 +181,8 @@
 - `Server.Close` is synchronous — returns only after all goroutines exit
 - Data race in `attachWS` buffer length check
 
-[Unreleased]: https://github.com/wspulse/hub/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/wspulse/hub/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/wspulse/hub/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/wspulse/hub/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/wspulse/hub/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/wspulse/hub/compare/v0.8.0...v0.9.0

--- a/export_test.go
+++ b/export_test.go
@@ -3,8 +3,6 @@ package wspulse
 import (
 	"net/http"
 	"time"
-
-	core "github.com/wspulse/core"
 )
 
 // DefaultPingInterval returns the default pingInterval from defaultConfig.
@@ -22,6 +20,12 @@ func DefaultWriteTimeout() time.Duration {
 // Clock exports the internal clock interface for testing only.
 type Clock = clock
 
+// Transport exports the internal transport interface for testing only.
+// A type alias (=) is used so that mock implementations in external _test
+// packages automatically satisfy the unexported transport interface without
+// an explicit cast. Same pattern as Clock = clock above.
+type Transport = transport
+
 // WithClock returns a HubOption that sets the clock. Test-only —
 // this file is only compiled during test builds.
 func WithClock(c Clock) HubOption {
@@ -34,7 +38,7 @@ func WithClock(c Clock) HubOption {
 // InjectTransport bypasses ServeHTTP and pushes a registerMessage directly
 // into the Hub's internal event loop. Test-only — allows component tests to
 // inject mock transports without HTTP upgrade.
-func InjectTransport(h Hub, connectionID, roomID string, transport core.Transport) {
+func InjectTransport(h Hub, connectionID, roomID string, transport Transport) {
 	if h == nil {
 		panic("wspulse: InjectTransport: hub must not be nil; use a hub created by NewHub")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
-	github.com/wspulse/core v0.4.0
+	github.com/wspulse/core v0.5.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wspulse/core v0.4.0 h1:ZYQSGPu1invHlD2iIfzqeHWu4eck6eBGqH4PCdFSIsk=
-github.com/wspulse/core v0.4.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
+github.com/wspulse/core v0.5.0 h1:6XOp0peQ5lASC68FLF5a4InPBwL9ZoBRQLjWkCnmFg0=
+github.com/wspulse/core v0.5.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/heart.go
+++ b/heart.go
@@ -7,7 +7,6 @@ import (
 
 	"go.uber.org/zap"
 
-	core "github.com/wspulse/core"
 	"github.com/wspulse/hub/ring"
 )
 
@@ -19,7 +18,7 @@ import (
 type registerMessage struct {
 	connectionID string
 	roomID       string
-	transport    core.Transport
+	transport    transport
 }
 
 // transportDiedMessage is sent by readPump when its WebSocket read loop exits.
@@ -27,8 +26,8 @@ type registerMessage struct {
 // destroy it (resume disabled / grace expired).
 type transportDiedMessage struct {
 	session   *session
-	transport core.Transport // the specific transport that died
-	err       error          // nil for normal closure
+	transport transport // the specific transport that died
+	err       error     // nil for normal closure
 }
 
 // graceExpiredMessage is sent by a time.AfterFunc when the resume window elapses

--- a/session.go
+++ b/session.go
@@ -243,7 +243,7 @@ func (s *session) Close() error {
 // all pre-resume frames precede post-resume frames in s.send.
 //
 // Must be called from the heart's event loop (single-goroutine serialization).
-func (s *session) attachWS(transport transport, h *heart, onResumeComplete func()) {
+func (s *session) attachWS(trans transport, h *heart, onResumeComplete func()) {
 	s.mu.Lock()
 
 	// Stop the previous pump group if still running.
@@ -252,7 +252,7 @@ func (s *session) attachWS(transport transport, h *heart, onResumeComplete func(
 	}
 	oldPumpDone := s.pumpDone
 
-	s.transport = transport
+	s.transport = trans
 	pumpCtx, pumpCancel := context.WithCancel(context.Background())
 	s.pumpCancel = pumpCancel
 	s.pumpDone = make(chan struct{})
@@ -343,7 +343,7 @@ func (s *session) attachWS(transport transport, h *heart, onResumeComplete func(
 		// do not start pumps on the stale/dead transport. Signal pumpDone so
 		// future transitions don't block waiting for this pump.
 		s.mu.Lock()
-		if s.transport != transport {
+		if s.transport != trans {
 			s.config.logger.Warn("wspulse: transition goroutine aborted — transport replaced or nil'd during drain",
 				zap.String("conn_id", s.id),
 			)
@@ -351,20 +351,20 @@ func (s *session) attachWS(transport transport, h *heart, onResumeComplete func(
 			// Close the orphaned transport — no pumps were started on it, so
 			// writePump's defer will never close it. Without this, the
 			// underlying TCP connection and file descriptor leak.
-			_ = transport.CloseNow()
+			_ = trans.CloseNow()
 			pumpCancel()
 			close(pumpDone)
 			return
 		}
 		s.mu.Unlock()
 
-		go s.readPump(pumpCtx, transport, h)
-		go s.writePump(pumpCtx, transport, pumpDone)
-		go s.pingPump(pumpCtx, transport)
+		go s.readPump(pumpCtx, trans, h)
+		go s.writePump(pumpCtx, trans, pumpDone)
+		go s.pingPump(pumpCtx, trans)
 
 		if onResumeComplete != nil {
 			s.mu.Lock()
-			shouldCall := s.state == stateConnected && s.transport == transport
+			shouldCall := s.state == stateConnected && s.transport == trans
 			s.mu.Unlock()
 			if shouldCall {
 				go onResumeComplete()
@@ -403,20 +403,20 @@ func (s *session) detachWS() (epoch uint64, ok bool) {
 // within writeTimeout. On failure, fires PongTimeout metric and calls
 // CloseNow() to force-close the transport (without cancelling the context,
 // so other pumps detect the error via their own I/O failures).
-func (s *session) pingPump(ctx context.Context, transport transport) {
+func (s *session) pingPump(ctx context.Context, trans transport) {
 	ticker := s.config.clock.NewTicker(s.config.pingInterval)
 	defer ticker.Stop()
 
 	// Send an initial ping immediately so dead-on-arrival connections are
 	// detected within writeTimeout instead of waiting a full pingInterval.
-	if !s.doPing(ctx, transport) {
+	if !s.doPing(ctx, trans) {
 		return
 	}
 
 	for {
 		select {
 		case <-ticker.C:
-			if !s.doPing(ctx, transport) {
+			if !s.doPing(ctx, trans) {
 				return
 			}
 		case <-ctx.Done():
@@ -427,9 +427,9 @@ func (s *session) pingPump(ctx context.Context, transport transport) {
 
 // doPing sends a single Ping with a writeTimeout deadline. Returns true if the
 // pong arrived successfully, false if the caller should exit.
-func (s *session) doPing(ctx context.Context, transport transport) bool {
+func (s *session) doPing(ctx context.Context, trans transport) bool {
 	pingCtx, cancel := context.WithTimeout(ctx, s.config.writeTimeout)
-	err := transport.Ping(pingCtx)
+	err := trans.Ping(pingCtx)
 	cancel()
 	if err != nil {
 		// context.Canceled means the pump context was cancelled (reconnect/close);
@@ -440,7 +440,7 @@ func (s *session) doPing(ctx context.Context, transport transport) bool {
 		s.config.metrics.PongTimeout(s.roomID, s.id)
 		s.config.logger.Debug("wspulse: pingPump stopping: ping failed",
 			zap.String("conn_id", s.id), zap.Error(err))
-		_ = transport.CloseNow()
+		_ = trans.CloseNow()
 		return false
 	}
 	return true
@@ -449,7 +449,7 @@ func (s *session) doPing(ctx context.Context, transport transport) bool {
 // readPump reads inbound messages from the transport and forwards them to the OnMessage
 // callback. When the read loop exits it signals the heart that this transport
 // has died. If the heart is shutting down, cleanup is handled inline.
-func (s *session) readPump(ctx context.Context, transport transport, h *heart) {
+func (s *session) readPump(ctx context.Context, trans transport, h *heart) {
 	var readErr error
 	defer func() {
 		// Recover from panics in OnMessage handlers.
@@ -465,7 +465,7 @@ func (s *session) readPump(ctx context.Context, transport transport, h *heart) {
 
 		// Notify the heart that this transport died.
 		select {
-		case h.transportDied <- transportDiedMessage{session: s, transport: transport, err: readErr}:
+		case h.transportDied <- transportDiedMessage{session: s, transport: trans, err: readErr}:
 		case <-h.done:
 			// Hub has stopped; clean up inline.
 		}
@@ -483,10 +483,10 @@ func (s *session) readPump(ctx context.Context, transport transport, h *heart) {
 		}
 	}()
 
-	transport.SetReadLimit(s.config.maxMessageSize)
+	trans.SetReadLimit(s.config.maxMessageSize)
 
 	for {
-		_, data, err := transport.Read(ctx)
+		_, data, err := trans.Read(ctx)
 		if err != nil {
 			if ctx.Err() != nil || isNormalClose(err) {
 				s.config.logger.Debug("wspulse: connection closed normally",
@@ -538,9 +538,9 @@ func isNormalClose(err error) bool {
 // force-closes the underlying connection so that readPump's Read unblocks.
 //
 // pumpDone is closed on exit so callers can wait for this pump to finish.
-func (s *session) writePump(ctx context.Context, transport transport, pumpDone chan struct{}) {
+func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan struct{}) {
 	defer func() {
-		_ = transport.CloseNow()
+		_ = trans.CloseNow()
 		close(pumpDone)
 	}()
 
@@ -568,14 +568,14 @@ func (s *session) writePump(ctx context.Context, transport transport, pumpDone c
 			// old transport may already be dead.
 			select {
 			case <-s.done:
-				_ = transport.Close(core.StatusNormalClosure, "")
+				_ = trans.Close(core.StatusNormalClosure, "")
 			default:
 			}
 			return
 		}
 
 		writeCtx, cancel := context.WithTimeout(ctx, s.config.writeTimeout)
-		err = transport.Write(writeCtx, s.config.codec.FrameType(), data)
+		err = trans.Write(writeCtx, s.config.codec.FrameType(), data)
 		cancel()
 		if err != nil {
 			if ctx.Err() != nil {

--- a/session.go
+++ b/session.go
@@ -71,7 +71,7 @@ type session struct {
 	done   chan struct{} // closed once to signal session termination; guarded by closeOnce
 
 	mu           sync.Mutex           // guards transport, pumpCancel, pumpDone, graceTimer, state, resumeBuffer, suspendEpoch
-	transport    core.Transport       // current physical connection; nil when suspended
+	transport    transport            // current physical connection; nil when suspended
 	pumpCancel   context.CancelFunc   // cancels the current pump context
 	pumpDone     chan struct{}        // closed by writePump on exit
 	graceTimer   *time.Timer          // resume window timer; nil when not suspended
@@ -243,7 +243,7 @@ func (s *session) Close() error {
 // all pre-resume frames precede post-resume frames in s.send.
 //
 // Must be called from the heart's event loop (single-goroutine serialization).
-func (s *session) attachWS(transport core.Transport, h *heart, onResumeComplete func()) {
+func (s *session) attachWS(transport transport, h *heart, onResumeComplete func()) {
 	s.mu.Lock()
 
 	// Stop the previous pump group if still running.
@@ -403,7 +403,7 @@ func (s *session) detachWS() (epoch uint64, ok bool) {
 // within writeTimeout. On failure, fires PongTimeout metric and calls
 // CloseNow() to force-close the transport (without cancelling the context,
 // so other pumps detect the error via their own I/O failures).
-func (s *session) pingPump(ctx context.Context, transport core.Transport) {
+func (s *session) pingPump(ctx context.Context, transport transport) {
 	ticker := s.config.clock.NewTicker(s.config.pingInterval)
 	defer ticker.Stop()
 
@@ -427,7 +427,7 @@ func (s *session) pingPump(ctx context.Context, transport core.Transport) {
 
 // doPing sends a single Ping with a writeTimeout deadline. Returns true if the
 // pong arrived successfully, false if the caller should exit.
-func (s *session) doPing(ctx context.Context, transport core.Transport) bool {
+func (s *session) doPing(ctx context.Context, transport transport) bool {
 	pingCtx, cancel := context.WithTimeout(ctx, s.config.writeTimeout)
 	err := transport.Ping(pingCtx)
 	cancel()
@@ -449,7 +449,7 @@ func (s *session) doPing(ctx context.Context, transport core.Transport) bool {
 // readPump reads inbound messages from the transport and forwards them to the OnMessage
 // callback. When the read loop exits it signals the heart that this transport
 // has died. If the heart is shutting down, cleanup is handled inline.
-func (s *session) readPump(ctx context.Context, transport core.Transport, h *heart) {
+func (s *session) readPump(ctx context.Context, transport transport, h *heart) {
 	var readErr error
 	defer func() {
 		// Recover from panics in OnMessage handlers.
@@ -538,7 +538,7 @@ func isNormalClose(err error) bool {
 // force-closes the underlying connection so that readPump's Read unblocks.
 //
 // pumpDone is closed on exit so callers can wait for this pump to finish.
-func (s *session) writePump(ctx context.Context, transport core.Transport, pumpDone chan struct{}) {
+func (s *session) writePump(ctx context.Context, transport transport, pumpDone chan struct{}) {
 	defer func() {
 		_ = transport.CloseNow()
 		close(pumpDone)

--- a/transport.go
+++ b/transport.go
@@ -8,7 +8,42 @@ import (
 	core "github.com/wspulse/core"
 )
 
-// coderTransport wraps *websocket.Conn to satisfy core.Transport.
+// transport abstracts the WebSocket connection for testability.
+// The API is context-based: deadlines are expressed via context cancellation
+// rather than explicit SetReadDeadline / SetWriteDeadline calls.
+//
+// Implementations must be comparable (== / !=). The heart uses interface
+// equality to detect stale transport-died notifications (see
+// handleTransportDied in heart.go). Pointer receiver types satisfy this
+// requirement naturally.
+type transport interface {
+	// Read reads the next message from the connection.
+	// Blocks until a message arrives, ctx is cancelled, or the connection closes.
+	Read(ctx context.Context) (core.MessageType, []byte, error)
+
+	// Write sends a message to the connection.
+	// ctx may carry a deadline for the write operation.
+	Write(ctx context.Context, typ core.MessageType, data []byte) error
+
+	// Ping sends a ping to the peer and waits for a pong.
+	// ctx may carry a deadline; if the pong does not arrive before the deadline,
+	// Ping returns an error and the connection should be considered dead.
+	Ping(ctx context.Context) error
+
+	// SetReadLimit sets the maximum size in bytes for a single message read
+	// from the connection. Messages exceeding this limit are rejected.
+	SetReadLimit(n int64)
+
+	// Close performs the WebSocket close handshake with the given status code
+	// and reason, then closes the underlying connection.
+	Close(code core.StatusCode, reason string) error
+
+	// CloseNow closes the underlying connection immediately without
+	// attempting a close handshake. Used in defer paths and error teardown.
+	CloseNow() error
+}
+
+// coderTransport wraps *websocket.Conn to satisfy the hub-local transport interface.
 // All conversions are thin type casts — MessageType and StatusCode values
 // are identical to RFC 6455, so no runtime calculation is needed.
 type coderTransport struct{ c *websocket.Conn }


### PR DESCRIPTION
## Summary

Release v0.9.3 — hub-local transport interface refactor and core dependency upgrade to v0.5.0.

## Related issues

Closes #52
Relates to wspulse/.github#39

## Changes

- Define hub-local unexported `transport` interface (replaces removed `core.Transport`)
- Upgrade `github.com/wspulse/core` v0.4.0 → v0.5.0
- Rename `transport` parameter to `trans` in pump methods to avoid type-name stuttering
- CHANGELOG entry for v0.9.3

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR