### PR TITLE
refactor: rename PongTimeout to HeartbeatFailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Renamed `MetricsCollector.PongTimeout` to `HeartbeatFailed`. The method fires
+  on any ping failure (pong timeout or transport error), not just timeouts. The
+  new name describes the outcome without implying a specific sub-case. No
+  behaviour change — only renaming.
+
 ## [0.9.3] - 2026-04-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The interface covers:
 | `MessageReceived` / `MessageSent` / `MessageBroadcast` | Throughput with byte sizes and fan-out |
 | `FrameDropped` / `SendBufferUtilization` | Backpressure visibility |
 | `ResumeAttempt` | Session resumption tracking |
-| `PongTimeout` | Heartbeat health |
+| `HeartbeatFailed` | Heartbeat health |
 
 Implement `MetricsCollector` to plug in any backend (Prometheus, OTel, or custom). See [doc/internals.md](doc/internals.md) for goroutine call sites and thread safety requirements.
 

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -331,7 +331,7 @@ must be safe for concurrent use.
 | `ResumeAttempt`         | heart goroutine       |
 | `MessageBroadcast`      | heart goroutine       |
 | `MessageReceived`       | readPump goroutine  |
-| `HeartbeatFailed`           | pingPump goroutine  |
+| `HeartbeatFailed`      | pingPump goroutine  |
 | `MessageSent`           | writePump goroutine |
 | `SendBufferUtilization` | writePump goroutine |
 | `FrameDropped`          | heart goroutine (broadcast), caller goroutine (Send), or transition goroutine (resume drain) |

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -28,7 +28,7 @@ attachWS(transport)
   ├─ go bridge          — propagates close(session.done) → pumpCancel()
   ├─ go readPump(ctx)   — reads inbound frames, calls OnMessage, signals heart on exit
   ├─ go writePump(ctx)  — drains session.send channel, sole writer of application data on transport
-  └─ go pingPump(ctx)   — drives Ping heartbeat, fires PongTimeout on failure
+  └─ go pingPump(ctx)   — drives Ping heartbeat, fires HeartbeatFailed on failure
 ```
 
 All pump goroutines share a single `pumpCtx` (derived from
@@ -53,7 +53,7 @@ first (e.g. by `detachWS` during resume), the bridge exits without effect.
   On graceful shutdown (`ctx.Done()`), it first sends a close frame via
   `transport.Close(StatusNormalClosure, "")`.
 - `pingPump` sends periodic Pings with a `writeTimeout` timeout. On failure it
-  fires the `PongTimeout` metric and calls `transport.CloseNow()` to force the
+  fires the `HeartbeatFailed` metric and calls `transport.CloseNow()` to force the
   transport closed, causing `readPump` to detect the error and signal the heart.
   An initial ping is sent immediately on startup to detect dead-on-arrival
   connections without waiting a full `pingInterval`.
@@ -111,7 +111,7 @@ wspulse.NewHub(connect,
    connections.
 
 2. **Timeout disconnect** — If `Ping(ctx)` returns an error (timeout or
-   network failure), `pingPump` fires the `PongTimeout` metric and calls
+   network failure), `pingPump` fires the `HeartbeatFailed` metric and calls
    `transport.CloseNow()` to force-close the underlying connection. This
    causes `readPump`'s `Read(ctx)` to return an error, which triggers the
    standard teardown path via `transportDiedMessage`.
@@ -331,7 +331,7 @@ must be safe for concurrent use.
 | `ResumeAttempt`         | heart goroutine       |
 | `MessageBroadcast`      | heart goroutine       |
 | `MessageReceived`       | readPump goroutine  |
-| `PongTimeout`           | pingPump goroutine  |
+| `HeartbeatFailed`           | pingPump goroutine  |
 | `MessageSent`           | writePump goroutine |
 | `SendBufferUtilization` | writePump goroutine |
 | `FrameDropped`          | heart goroutine (broadcast), caller goroutine (Send), or transition goroutine (resume drain) |

--- a/metrics.go
+++ b/metrics.go
@@ -109,9 +109,9 @@ type MetricsCollector interface {
 	// Implementations should apply sampling, batching, or throttling as needed.
 	SendBufferUtilization(roomID, connectionID string, used, capacity int)
 
-	// PongTimeout is called when a Ping fails (timeout or transport error),
-	// indicating the remote peer is unreachable.
-	PongTimeout(roomID, connectionID string)
+	// HeartbeatFailed is called when a Ping fails (pong timeout or transport
+	// error), indicating the remote peer is unreachable.
+	HeartbeatFailed(roomID, connectionID string)
 }
 
 // NoopCollector is the default MetricsCollector that discards all events.
@@ -158,5 +158,5 @@ func (NoopCollector) FrameDropped(_, _ string) {}
 // SendBufferUtilization is a no-op. See MetricsCollector.SendBufferUtilization.
 func (NoopCollector) SendBufferUtilization(_, _ string, _, _ int) {}
 
-// PongTimeout is a no-op. See MetricsCollector.PongTimeout.
-func (NoopCollector) PongTimeout(_, _ string) {}
+// HeartbeatFailed is a no-op. See MetricsCollector.HeartbeatFailed.
+func (NoopCollector) HeartbeatFailed(_, _ string) {}

--- a/metrics_hook_test.go
+++ b/metrics_hook_test.go
@@ -261,11 +261,11 @@ func TestMetricsCollector_FrameDropped_BroadcastDropOldest(t *testing.T) {
 	}
 }
 
-// ── Metrics: pong timeout ───────────────────────────────────────────────────
-// PongTimeout is fired by pingPump when transport.Ping() fails. Install a
+// ── Metrics: heartbeat failed ────────────────────────────────────────────────
+// HeartbeatFailed is fired by pingPump when transport.Ping() fails. Install a
 // ping handler that blocks until signalled, then returns an error.
 
-func TestMetricsCollector_PongTimeout(t *testing.T) {
+func TestMetricsCollector_HeartbeatFailed(t *testing.T) {
 	t.Parallel()
 	rec := &recordingCollector{}
 	connected := make(chan struct{}, 1)
@@ -308,7 +308,7 @@ func TestMetricsCollector_PongTimeout(t *testing.T) {
 
 	requireReceive(t, disconnected)
 
-	assert.Equal(t, 1, rec.countByName("PongTimeout"), "PongTimeout")
+	assert.Equal(t, 1, rec.countByName("HeartbeatFailed"), "HeartbeatFailed")
 }
 
 // ── Metrics: shutdown ───────────────────────────────────────────────────────

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -32,7 +32,7 @@ func TestNoopCollector_AllMethodsCallable(t *testing.T) {
 	c.MessageSent("room", "conn", 100)
 	c.FrameDropped("room", "conn")
 	c.SendBufferUtilization("room", "conn", 10, 256)
-	c.PongTimeout("room", "conn")
+	c.HeartbeatFailed("room", "conn")
 }
 
 // ── WithMetrics option ────────────────────────────────────────────────────────
@@ -121,8 +121,8 @@ func (r *recordingCollector) FrameDropped(roomID, connectionID string) {
 func (r *recordingCollector) SendBufferUtilization(roomID, connectionID string, used, capacity int) {
 	r.record(metricsEvent{name: "SendBufferUtilization", roomID: roomID, connectionID: connectionID, used: used, capacity: capacity})
 }
-func (r *recordingCollector) PongTimeout(roomID, connectionID string) {
-	r.record(metricsEvent{name: "PongTimeout", roomID: roomID, connectionID: connectionID})
+func (r *recordingCollector) HeartbeatFailed(roomID, connectionID string) {
+	r.record(metricsEvent{name: "HeartbeatFailed", roomID: roomID, connectionID: connectionID})
 }
 
 var _ wspulse.MetricsCollector = (*recordingCollector)(nil)

--- a/session.go
+++ b/session.go
@@ -433,7 +433,7 @@ func (s *session) doPing(ctx context.Context, trans transport) bool {
 	cancel()
 	if err != nil {
 		// context.Canceled means the pump context was cancelled (reconnect/close);
-		// this is not a pong timeout — exit silently without firing the metric.
+		// this is not a heartbeat failure — exit silently without firing the metric.
 		if ctx.Err() != nil {
 			return false
 		}

--- a/session.go
+++ b/session.go
@@ -58,7 +58,7 @@ const (
 // Goroutine ownership:
 //   - readPump  : reads from transport, forwards decoded Frames to onMessage.
 //   - writePump : sole writer of application data frames on transport; drains session.send.
-//   - pingPump  : drives Ping heartbeat; fires PongTimeout metric on failure.
+//   - pingPump  : drives Ping heartbeat; fires HeartbeatFailed metric on failure.
 //
 // Lifecycle signal flow:
 //
@@ -400,7 +400,7 @@ func (s *session) detachWS() (epoch uint64, ok bool) {
 
 // pingPump drives the heartbeat ping/pong mechanism on the transport.
 // Sends a Ping at each tick of pingInterval and waits for the pong reply
-// within writeTimeout. On failure, fires PongTimeout metric and calls
+// within writeTimeout. On failure, fires HeartbeatFailed metric and calls
 // CloseNow() to force-close the transport (without cancelling the context,
 // so other pumps detect the error via their own I/O failures).
 func (s *session) pingPump(ctx context.Context, trans transport) {
@@ -437,7 +437,7 @@ func (s *session) doPing(ctx context.Context, trans transport) bool {
 		if ctx.Err() != nil {
 			return false
 		}
-		s.config.metrics.PongTimeout(s.roomID, s.id)
+		s.config.metrics.HeartbeatFailed(s.roomID, s.id)
 		s.config.logger.Debug("wspulse: pingPump stopping: ping failed",
 			zap.String("conn_id", s.id), zap.Error(err))
 		_ = trans.CloseNow()


### PR DESCRIPTION
## Summary

Rename `MetricsCollector.PongTimeout` to `HeartbeatFailed`. The method fires on any ping failure (pong timeout or transport error), not just timeouts. The new name describes the outcome without implying a specific sub-case.

## Related issues

Closes #43
Relates to wspulse/.github#35

## Changes

- Renamed interface method `PongTimeout` → `HeartbeatFailed` in `MetricsCollector`
- Renamed `NoopCollector.PongTimeout` → `NoopCollector.HeartbeatFailed`
- Updated call site in `session.go` (`doPing`)
- Updated comments in `session.go` (goroutine ownership, pingPump GoDoc)
- Updated `recordingCollector` in `metrics_test.go`
- Renamed `TestMetricsCollector_PongTimeout` → `TestMetricsCollector_HeartbeatFailed`
- Updated `doc/internals.md` (4 occurrences) and `README.md` metrics table
- CHANGELOG entry under Breaking changes

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue
- [x] New public API: includes GoDoc comments