### PR TITLE
Release v0.11.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-wspulse/hub is a **minimal, production-ready WebSocket server library** for Go. It manages concurrent connections, room-based broadcasting, session resumption, and heartbeat. Module path: `github.com/wspulse/hub`. Package name: `wspulse`. Depends on `github.com/wspulse/core` for shared types (`Frame`, `Codec`).
+wspulse/hub is a **minimal, production-ready WebSocket server library** for Go. It manages concurrent connections, room-based broadcasting, session resumption, and heartbeat. Module path: `github.com/wspulse/hub`. Package name: `wspulse`. Depends on `github.com/wspulse/core` for shared types (`Message`, `Codec`).
 
 ## Architecture
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ wspulse/hub is a **minimal, production-ready WebSocket server library** for Go. 
 - **`heart.go`** — Central single-threaded event loop. Manages all sessions and routes messages via channels. No `net/http` imports.
 - **`session.go`** — `Connection` interface and the unexported `session` struct. Per-connection `readPump` + `writePump` goroutine pair; ping/pong heartbeat; backpressure drop.
 - **`options.go`** — `HubOption` functional options, `ConnectFunc` type, and all `WithXxx` option builders.
-- **`resume.go`** — Ring buffer for buffering frames during temporary disconnects (session resumption).
+- **`resume.go`** — Ring buffer for buffering messages during temporary disconnects (session resumption).
 - **`errors.go`** — Hub-only sentinel errors: `ErrConnectionNotFound`, `ErrDuplicateConnectionID`, `ErrHubClosed`.
 - **`doc/internals.md`** — Internal architecture documentation.
 - Wire protocol specification has moved to the [`.github` repo](https://github.com/wspulse/.github/blob/main/doc/protocol.md).
@@ -50,7 +50,7 @@ make tidy             # tidy module dependencies
 - **Tests**: co-located with source (`_test.go`). Cover happy path and at least one error path. Required for new public functions.
   - **Component tests**: tests use mock transports (`mockTransport`) via `InjectTransport` — no real WebSocket connections needed. All tests run with `make test`.
   - **Test-first for bug fixes**: **mandatory** — see Critical Rule 7 for the required step-by-step procedure. Do not touch production code without a prior failing test.
-  - **Benchmarks**: changes to ring buffer, broadcast fan-out, or frame encoding must include a benchmark. Verify with `make bench`.
+  - **Benchmarks**: changes to ring buffer, broadcast fan-out, or message encoding must include a benchmark. Verify with `make bench`.
 - **API compatibility**:
   - Exported symbols are a public contract. Changing or removing any exported identifier is a breaking change requiring a major version bump.
   - Adding a method to an exported interface breaks all external implementations — treat it as a breaking change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Renamed `Frame` type alias to `Message` (re-exported from core).
+  Affects: `Hub.Send`, `Hub.Broadcast`, `Connection.Send`, `ConnectFunc`
+  callbacks via `WithOnMessage`.
+- Renamed `MetricsCollector.FrameDropped` to `MessageDropped`.
+  Custom `MetricsCollector` implementations must rename this method.
+- `Codec` interface method `FrameType()` renamed to `WireType()` (upstream
+  core change). Custom `Codec` implementations must rename this method.
+
 ## [0.10.0] - 2026-04-17
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Breaking changes
 
 - Renamed `Frame` type alias to `Message` (re-exported from core).
-  Affects: `Hub.Send`, `Hub.Broadcast`, `Connection.Send`, `ConnectFunc`
-  callbacks via `WithOnMessage`.
+  Affects: `Hub.Send`, `Hub.Broadcast`, `Connection.Send`,
+  `WithOnMessage` callback signature.
 - Renamed `MetricsCollector.FrameDropped` to `MessageDropped`.
   Custom `MetricsCollector` implementations must rename this method.
 - `Codec` interface method `FrameType()` renamed to `WireType()` (upstream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-20
+
 ### Breaking changes
 
 - Renamed `Frame` type alias to `Message` (re-exported from core).
@@ -200,7 +202,8 @@
 - `Server.Close` is synchronous — returns only after all goroutines exit
 - Data race in `attachWS` buffer length check
 
-[Unreleased]: https://github.com/wspulse/hub/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/wspulse/hub/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/wspulse/hub/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/wspulse/hub/compare/v0.9.3...v0.10.0
 [0.9.3]: https://github.com/wspulse/hub/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/wspulse/hub/compare/v0.9.1...v0.9.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ wspulse/hub follows semantic versioning. Any change that removes, renames, or al
 
 ## Performance-Sensitive Changes
 
-Changes to ring buffer, broadcast fan-out, or frame encoding must include a benchmark. Run `make bench` and include before/after numbers in the PR description.
+Changes to ring buffer, broadcast fan-out, or message encoding must include a benchmark. Run `make bench` and include before/after numbers in the PR description.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The router from [wspulse/core](https://github.com/wspulse/core) integrates direc
 }
 ```
 
-The value of `"event"` is `msg.Event` on the Go side, and is the key used to select the handler.
+The value of `"event"` is `Message.Event` on the Go side, and is the key used to select the handler.
 
 ```go
 import (

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A minimal, production-ready WebSocket server for Go with room-based routing, ses
 ## Design Goals
 
 - Thin transport layer: no business logic, no auth, no message history
-- Three public concepts: `Hub`, `Connection`, `Frame`
+- Three public concepts: `Hub`, `Connection`, `Message`
 - Plug in any HTTP router via `http.Handler`
 - Swappable codecs: JSON (default) or binary (e.g. Protobuf)
 - Transparent session resumption with configurable grace window
@@ -45,7 +45,7 @@ srv = wspulse.NewHub(
         }
         return r.URL.Query().Get("room"), userID, nil
     },
-    wspulse.WithOnMessage(func(connection wspulse.Connection, f wspulse.Frame) {
+    wspulse.WithOnMessage(func(connection wspulse.Connection, f wspulse.Message) {
         // echo back to the whole room
         srv.Broadcast(connection.RoomID(), f)
     }),
@@ -69,11 +69,11 @@ router.GET("/ws", func(c *gin.Context) {
 
 ```go
 // Send to a specific connection
-srv.Send(connectionID, wspulse.Frame{Event: "sys", Payload: []byte(`{"event":"welcome"}`)})
+srv.Send(connectionID, wspulse.Message{Event: "sys", Payload: []byte(`{"event":"welcome"}`)})
 
 // Broadcast to a room
 payload, _ := json.Marshal(myMessage)
-srv.Broadcast(roomID, wspulse.Frame{Event: "msg", Payload: payload})
+srv.Broadcast(roomID, wspulse.Message{Event: "msg", Payload: payload})
 
 // Kick a connection
 srv.Kick(connectionID)
@@ -96,17 +96,17 @@ rtr := router.New()
 rtr.Use(router.Recovery()) // recover from panics in handlers
 
 rtr.On("chat.message", func(c *router.Context) {
-    srv.Broadcast(c.Connection.RoomID(), c.Frame)
+    srv.Broadcast(c.Connection.RoomID(), c.Message)
 })
 rtr.On("chat.join", func(c *router.Context) {
-    welcome := wspulse.Frame{Event: "chat.welcome", Payload: []byte(`"hello"`)}
+    welcome := wspulse.Message{Event: "chat.welcome", Payload: []byte(`"hello"`)}
     _ = c.Connection.Send(welcome)
 })
 
 var srv wspulse.Hub
 srv = wspulse.NewHub(
     connectFunc,
-    wspulse.WithOnMessage(func(conn wspulse.Connection, f wspulse.Frame) {
+    wspulse.WithOnMessage(func(conn wspulse.Connection, f wspulse.Message) {
         rtr.Dispatch(conn, f)
     }),
 )
@@ -122,10 +122,10 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | ------------- | ----------------------------------------------------------------------- |
 | `Hub`         | Manages sessions, heartbeats, and room routing                          |
 | `Connection`  | A logical WebSocket session (`ID`, `RoomID`, `Send`, `Close`, `Done`)   |
-| `Frame`       | Transport unit (`Event`, `Payload []byte`) — re-exported from core       |
+| `Message`     | Transport unit (`Event`, `Payload []byte`) — re-exported from core       |
 | `ConnectFunc` | `func(*http.Request) (roomID, connectionID string, err error)`          |
-| `Codec`       | Interface: `Encode(Frame)`, `Decode([]byte)`, `FrameType()` — from core |
-| `JSONCodec`   | Default codec — text frames, JSON payload — re-exported from core       |
+| `Codec`       | Interface: `Encode(Message)`, `Decode([]byte)`, `WireType()` — from core |
+| `JSONCodec`   | Default codec — text messages, JSON payload — re-exported from core     |
 
 ### Hub options
 
@@ -140,7 +140,7 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | `WithPingInterval(d)`       | 20 s                                 |
 | `WithWriteTimeout(d)`       | 10 s                                 |
 | `WithMaxMessageSize(n)`     | 512 B                                |
-| `WithSendBufferSize(n)`     | 256 frames                           |
+| `WithSendBufferSize(n)`     | 256 messages                         |
 | `WithCodec(c)`              | JSONCodec                            |
 | `WithLogger(l)`             | zap.NewNop() — accepts `*zap.Logger` |
 | `WithMetrics(mc)`           | NoopCollector — accepts `MetricsCollector` |
@@ -151,9 +151,9 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 
 - **Room-based routing** — connections are partitioned into rooms; broadcast targets a single room.
 - **Pluggable auth** — `ConnectFunc` runs during HTTP Upgrade, before any WebSocket frames are exchanged.
-- **Session resumption** — opt-in via `WithResumeWindow(d)`. When a transport drops, the session is suspended for `d` before firing `OnDisconnect`. If the client reconnects with the same `connectionID` within that window, the new WebSocket is swapped in transparently — no `OnConnect` / `OnDisconnect` callbacks fire, and buffered frames are replayed in order. Disabled by default.
+- **Session resumption** — opt-in via `WithResumeWindow(d)`. When a transport drops, the session is suspended for `d` before firing `OnDisconnect`. If the client reconnects with the same `connectionID` within that window, the new WebSocket is swapped in transparently — no `OnConnect` / `OnDisconnect` callbacks fire, and buffered messages are replayed in order. Disabled by default.
 - **Automatic heartbeat** — server-side Ping / Pong with configurable interval (`WithPingInterval`) and write timeout (`WithWriteTimeout`).
-- **Backpressure** — bounded per-connection send buffer; oldest frame is dropped on overflow during broadcast.
+- **Backpressure** — bounded per-connection send buffer; oldest message is dropped on overflow during broadcast.
 - **Swappable codec** — JSON by default; implement the `Codec` interface to plug in any encoding (binary, Protobuf, MessagePack, etc.).
 - **Kick** — `Hub.Kick(connectionID)` always destroys the session immediately, bypassing the resume window.
 - **Graceful shutdown** — `Hub.Close()` sends close frames to all connected clients, drains in-flight registrations, and fires `OnDisconnect` for every session.
@@ -182,7 +182,7 @@ The interface covers:
 | `ConnectionOpened` / `ConnectionClosed` | Session lifecycle with duration and disconnect reason |
 | `RoomCreated` / `RoomDestroyed` | Room allocation and deallocation |
 | `MessageReceived` / `MessageSent` / `MessageBroadcast` | Throughput with byte sizes and fan-out |
-| `FrameDropped` / `SendBufferUtilization` | Backpressure visibility |
+| `MessageDropped` / `SendBufferUtilization` | Backpressure visibility |
 | `ResumeAttempt` | Session resumption tracking |
 | `HeartbeatFailed` | Heartbeat health |
 
@@ -190,9 +190,9 @@ Implement `MetricsCollector` to plug in any backend (Prometheus, OTel, or custom
 
 ---
 
-## Frame Routing with `core/router`
+## Message Routing with `core/router`
 
-The router from [wspulse/core](https://github.com/wspulse/core) integrates directly with `WithOnMessage`. It dispatches each incoming frame to its handler based on the **`"event"` field** in the JSON message:
+The router from [wspulse/core](https://github.com/wspulse/core) integrates directly with `WithOnMessage`. It dispatches each incoming message to its handler based on the **`"event"` field** in the JSON payload:
 
 ```json
 {
@@ -201,7 +201,7 @@ The router from [wspulse/core](https://github.com/wspulse/core) integrates direc
 }
 ```
 
-The value of `"event"` is `frame.Event` on the Go side, and is the key used to select the handler.
+The value of `"event"` is `msg.Event` on the Go side, and is the key used to select the handler.
 
 ```go
 import (
@@ -219,22 +219,22 @@ r.Use(func(c *router.Context) {
     c.Next()
 })
 
-// matches frames where "event" == "chat.message"
+// matches messages where "event" == "chat.message"
 r.On("chat.message", func(c *router.Context) {
-    srv.Broadcast(c.Connection.RoomID(), wspulse.Frame{
+    srv.Broadcast(c.Connection.RoomID(), wspulse.Message{
         Event:   "chat.message",
-        Payload: c.Frame.Payload,
+        Payload: c.Message.Payload,
     })
 })
 
-// matches frames where "event" == "ping"
+// matches messages where "event" == "ping"
 r.On("ping", func(c *router.Context) {
-    _ = c.Connection.Send(wspulse.Frame{Event: "pong"})
+    _ = c.Connection.Send(wspulse.Message{Event: "pong"})
 })
 
 srv = wspulse.NewHub(
     connectFn,
-    wspulse.WithOnMessage(func(conn wspulse.Connection, f wspulse.Frame) {
+    wspulse.WithOnMessage(func(conn wspulse.Connection, f wspulse.Message) {
         r.Dispatch(conn, f)
     }),
 )

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -26,7 +26,7 @@ plus one dedicated **bridge goroutine**:
 ```
 attachWS(transport)
   ├─ go bridge          — propagates close(session.done) → pumpCancel()
-  ├─ go readPump(ctx)   — reads inbound frames, calls OnMessage, signals heart on exit
+  ├─ go readPump(ctx)   — reads inbound messages, calls OnMessage, signals heart on exit
   ├─ go writePump(ctx)  — drains session.send channel, sole writer of application data on transport
   └─ go pingPump(ctx)   — drives Ping heartbeat, fires HeartbeatFailed on failure
 ```
@@ -65,7 +65,7 @@ first (e.g. by `detachWS` during resume), the bridge exits without effect.
   `session.Close()` after `done` is closed, which unblocks any goroutine
   blocked in `sendQueue.Pop`. This eliminates the TOCTOU race present in the
   previous three-select drop-oldest pattern.
-- `writePump` calls `s.send.Pop(pumpCtx)`, which blocks until a frame is
+- `writePump` calls `s.send.Pop(pumpCtx)`, which blocks until a message is
   available, the context is cancelled, or the queue is closed.
 
 ---
@@ -130,22 +130,22 @@ Each session maintains a `session.send *sendQueue` — a mutex-guarded
 `ring.Buffer[[]byte]` with a `sync.Cond` for blocking `Pop`. Its capacity
 is configurable (default **256**). When `Hub.Broadcast` or `Hub.Send` is called:
 
-1. The encoded frame bytes are passed to `sendQueue.Enqueue` or
+1. The encoded message bytes are passed to `sendQueue.Enqueue` or
    `sendQueue.ForceEnqueue` (both hold the mutex for the entire operation).
 2. If the buffer is **full**, `ErrSendBufferFull` is returned to the caller
    (for direct `Send`, via `Enqueue`) or **drop-oldest** backpressure is applied
-   atomically (for `Broadcast`, via `ForceEnqueue`): the oldest frame is evicted
-   and the new frame is inserted in a single critical section — no TOCTOU race.
+   atomically (for `Broadcast`, via `ForceEnqueue`): the oldest message is evicted
+   and the new message is inserted in a single critical section — no TOCTOU race.
 3. When `resumeWindow > 0` and the session is suspended (no active WebSocket),
-   frames are buffered to an in-memory `ring.Buffer` instead of the send queue.
-   These frames are replayed when the client reconnects.
+   messages are buffered to an in-memory `ring.Buffer` instead of the send queue.
+   These messages are replayed when the client reconnects.
 
 This ensures a slow or lagging connection cannot block the heart event loop or
 stall broadcasts to other healthy connections.
 
 If the application needs reliable delivery for a specific connection, it should
 call `connection.Send` directly and handle `ErrSendBufferFull` at the call
-site — for example, by scheduling a retry or incrementing a dropped-frames
+site — for example, by scheduling a retry or incrementing a dropped-messages
 metric.
 
 ---
@@ -203,7 +203,7 @@ swapped in silently.
 ```
 [*] → Connected : handleRegister creates session + transport
 
-Connected → Suspended : transport dies, resumeWindow > 0 (start timer, buffer frames, onTransportDrop fires)
+Connected → Suspended : transport dies, resumeWindow > 0 (start timer, buffer messages, onTransportDrop fires)
 Connected → Closed    : transport dies, resumeWindow == 0 (onDisconnect fires)
 Connected → Closed    : Kick() or Close() (onDisconnect fires)
 Connected → Closed    : duplicate connectionID arrives (old session kicked, onDisconnect fires with ErrDuplicateConnectionID; new session created)
@@ -223,7 +223,7 @@ WS1 connection drops
   → WS1 sends transportDiedMessage(session, err) to Heart
   → Heart detaches WS1, starts resumeWindow timer
   → go onTransportDrop(session, err)
-  → Session state = suspended, frames buffered to ringBuffer
+  → Session state = suspended, messages buffered to ringBuffer
 
 WS2 client reconnects with same connectionID
   → WS2 sends register(connectionID, transport) to Heart
@@ -239,13 +239,13 @@ connection.
 
 ### Resume Buffer
 
-During the suspended state, frames sent via `session.Send()` or
+During the suspended state, messages sent via `session.Send()` or
 `Hub.Broadcast()` are stored in an in-memory `ringBuffer` with a capacity
-equal to `sendBufferSize` (default 256 frames). When the buffer is full, the
-oldest frame is dropped (same backpressure strategy as the send channel during
+equal to `sendBufferSize` (default 256 messages). When the buffer is full, the
+oldest message is dropped (same backpressure strategy as the send channel during
 normal operation).
 
-On reconnect, buffered frames are drained from the ring buffer into the send
+On reconnect, buffered messages are drained from the ring buffer into the send
 channel before the new `writePump` starts, ensuring ordering is preserved.
 
 ### Effective Reconnect Window
@@ -334,7 +334,7 @@ must be safe for concurrent use.
 | `HeartbeatFailed`      | pingPump goroutine  |
 | `MessageSent`           | writePump goroutine |
 | `SendBufferUtilization` | writePump goroutine |
-| `FrameDropped`          | heart goroutine (broadcast), caller goroutine (Send), or transition goroutine (resume drain) |
+| `MessageDropped`        | heart goroutine (broadcast), caller goroutine (Send), or transition goroutine (resume drain) |
 
 ### Connection duration
 

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -242,11 +242,11 @@ connection.
 During the suspended state, messages sent via `session.Send()` or
 `Hub.Broadcast()` are stored in an in-memory `ringBuffer` with a capacity
 equal to `sendBufferSize` (default 256 messages). When the buffer is full, the
-oldest message is dropped (same backpressure strategy as the send channel during
+oldest message is dropped (same backpressure strategy as the send queue during
 normal operation).
 
 On reconnect, buffered messages are drained from the ring buffer into the send
-channel before the new `writePump` starts, ensuring ordering is preserved.
+queue before the new `writePump` starts, ensuring ordering is preserved.
 
 ### Effective Reconnect Window
 

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -228,7 +228,7 @@ WS1 connection drops
 WS2 client reconnects with same connectionID
   → WS2 sends register(connectionID, transport) to Heart
   → Heart cancels timer
-  → Heart attaches WS2, drains ringBuffer to send channel
+  → Heart attaches WS2, drains ringBuffer to send queue
   → Heart starts readPump(WS2) + writePump(WS2) + pingPump(WS2)
   → onTransportRestore fires; no onConnect / onDisconnect fired
 ```

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -27,7 +27,7 @@ plus one dedicated **bridge goroutine**:
 attachWS(transport)
   ├─ go bridge          — propagates close(session.done) → pumpCancel()
   ├─ go readPump(ctx)   — reads inbound messages, calls OnMessage, signals heart on exit
-  ├─ go writePump(ctx)  — drains session.send channel, sole writer of application data on transport
+  ├─ go writePump(ctx)  — drains the session send queue, sole writer of application data on transport
   └─ go pingPump(ctx)   — drives Ping heartbeat, fires HeartbeatFailed on failure
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
-	github.com/wspulse/core v0.5.0
+	github.com/wspulse/core v0.6.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wspulse/core v0.5.0 h1:6XOp0peQ5lASC68FLF5a4InPBwL9ZoBRQLjWkCnmFg0=
-github.com/wspulse/core v0.5.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
+github.com/wspulse/core v0.6.0 h1:eU+xYnEAu2hqvLPIrwxTYyXCFz7GHweqKwh0klxh/k0=
+github.com/wspulse/core v0.6.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/heart_test.go
+++ b/heart_test.go
@@ -105,7 +105,7 @@ func TestBroadcast_ReachesConnectedClient(t *testing.T) {
 
 // ── Send ─────────────────────────────────────────────────────────────────────
 
-func TestSend_DeliversFrameToConnection(t *testing.T) {
+func TestSend_DeliversMessageToConnection(t *testing.T) {
 	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewHub(

--- a/heart_test.go
+++ b/heart_test.go
@@ -28,13 +28,13 @@ func injectAndWait(t *testing.T, srv wspulse.Hub, connectionID, roomID string, c
 
 // ── OnConnect ────────────────────────────────────────────────────────────────
 
-func TestOnConnect_SendsFrame(t *testing.T) {
+func TestOnConnect_SendsMessage(t *testing.T) {
 	t.Parallel()
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewHub(
 		acceptAll,
 		wspulse.WithOnConnect(func(connection wspulse.Connection) {
-			_ = connection.Send(wspulse.Frame{Event: "welcome", Payload: []byte(`"hello"`)})
+			_ = connection.Send(wspulse.Message{Event: "welcome", Payload: []byte(`"hello"`)})
 			connected <- struct{}{}
 		}),
 	)
@@ -42,7 +42,7 @@ func TestOnConnect_SendsFrame(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
-	// writePump encodes the frame and writes to mock transport.
+	// writePump encodes the message and writes to mock transport.
 	w, ok := mt.WaitWrite(time.Second)
 	require.True(t, ok, "expected a write from writePump")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -55,13 +55,13 @@ func TestOnConnect_SendsFrame(t *testing.T) {
 func TestOnMessage_CallbackFires(t *testing.T) {
 	t.Parallel()
 	connected := make(chan struct{}, 1)
-	received := make(chan wspulse.Frame, 1)
+	received := make(chan wspulse.Message, 1)
 	srv := wspulse.NewHub(
 		acceptAll,
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			connected <- struct{}{}
 		}),
-		wspulse.WithOnMessage(func(_ wspulse.Connection, f wspulse.Frame) {
+		wspulse.WithOnMessage(func(_ wspulse.Connection, f wspulse.Message) {
 			received <- f
 		}),
 	)
@@ -70,7 +70,7 @@ func TestOnMessage_CallbackFires(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// Inject a message into readPump via mock transport.
-	encoded, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "msg", Payload: []byte(`{"text":"hello"}`)})
+	encoded, err := wspulse.JSONCodec.Encode(wspulse.Message{Event: "msg", Payload: []byte(`{"text":"hello"}`)})
 	require.NoError(t, err)
 	mt.InjectMessage(wspulse.TextMessage, encoded)
 
@@ -93,8 +93,8 @@ func TestBroadcast_ReachesConnectedClient(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
-	frame := wspulse.Frame{Event: "notice", Payload: []byte(`"hello room"`)}
-	require.NoError(t, srv.Broadcast("test-room", frame))
+	msg := wspulse.Message{Event: "notice", Payload: []byte(`"hello room"`)}
+	require.NoError(t, srv.Broadcast("test-room", msg))
 
 	w, ok := mt.WaitWrite(time.Second)
 	require.True(t, ok, "expected broadcast write")
@@ -118,8 +118,8 @@ func TestSend_DeliversFrameToConnection(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
-	frame := wspulse.Frame{Event: "direct", Payload: []byte(`"hi"`)}
-	require.NoError(t, srv.Send("test-connection", frame))
+	msg := wspulse.Message{Event: "direct", Payload: []byte(`"hi"`)}
+	require.NoError(t, srv.Send("test-connection", msg))
 
 	w, ok := mt.WaitWrite(time.Second)
 	require.True(t, ok, "expected direct send write")
@@ -230,8 +230,8 @@ func TestDuplicateConnectionID_OldKickedNewReachable(t *testing.T) {
 	requireReceive(t, connected)
 
 	// Verify second connection is reachable.
-	frame := wspulse.Frame{Event: "ok", Payload: []byte(`"after-kick"`)}
-	require.NoError(t, srv.Send("test-connection", frame))
+	msg := wspulse.Message{Event: "ok", Payload: []byte(`"after-kick"`)}
+	require.NoError(t, srv.Send("test-connection", msg))
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected write to second connection")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -268,7 +268,7 @@ func TestBroadcast_EmptyRoom_NoError(t *testing.T) {
 	t.Parallel()
 	srv := wspulse.NewHub(acceptAll)
 	t.Cleanup(srv.Close)
-	err := srv.Broadcast("nonexistent-room", wspulse.Frame{Event: "msg"})
+	err := srv.Broadcast("nonexistent-room", wspulse.Message{Event: "msg"})
 	require.NoError(t, err)
 }
 
@@ -302,7 +302,7 @@ func TestMultipleRooms_BroadcastIsolation(t *testing.T) {
 	mtB := injectAndWait(t, srv, "conn-b", "room-b", connectedB)
 
 	// Broadcast to room-a only.
-	require.NoError(t, srv.Broadcast("room-a", wspulse.Frame{Event: "hello"}))
+	require.NoError(t, srv.Broadcast("room-a", wspulse.Message{Event: "hello"}))
 
 	// room-a client should receive it.
 	w, ok := mtA.WaitWrite(time.Second)
@@ -388,7 +388,7 @@ func TestConnectionSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T) {
 	// Rapid-fire send to fill the buffer.
 	var gotBufferFull bool
 	for i := 0; i < 200; i++ {
-		err := conn.Send(wspulse.Frame{Event: "flood"})
+		err := conn.Send(wspulse.Message{Event: "flood"})
 		if errors.Is(err, wspulse.ErrSendBufferFull) {
 			gotBufferFull = true
 			break

--- a/metrics.go
+++ b/metrics.go
@@ -84,22 +84,22 @@ type MetricsCollector interface {
 	// message is read, before decoding. sizeBytes is the raw wire size.
 	MessageReceived(roomID string, sizeBytes int)
 
-	// MessageBroadcast is called after a broadcast frame is fanned out to
-	// all sessions in a room. sizeBytes is the pre-encoded frame size;
+	// MessageBroadcast is called after a broadcast message is fanned out to
+	// all sessions in a room. sizeBytes is the pre-encoded message size;
 	// fanOut is the number of recipient sessions (including suspended ones).
 	MessageBroadcast(roomID string, sizeBytes int, fanOut int)
 
-	// MessageSent is called in the writePump after a frame is successfully
-	// written to the WebSocket transport. sizeBytes is the encoded frame size.
+	// MessageSent is called in the writePump after a message is successfully
+	// written to the WebSocket transport. sizeBytes is the encoded message size.
 	MessageSent(roomID, connectionID string, sizeBytes int)
 
-	// FrameDropped is called whenever a frame is discarded due to send buffer
+	// MessageDropped is called whenever a message is discarded due to send buffer
 	// backpressure. This covers drops from Send (buffer full), Broadcast
 	// (drop-oldest), and resume drain (buffer full during replay).
-	// In the drop-oldest path, two FrameDropped events may fire: one for the
-	// oldest frame evicted and one for the new frame if it still cannot be
-	// enqueued — both represent real frame loss.
-	FrameDropped(roomID, connectionID string)
+	// In the drop-oldest path, two MessageDropped events may fire: one for the
+	// oldest message evicted and one for the new message if it still cannot be
+	// enqueued — both represent real message loss.
+	MessageDropped(roomID, connectionID string)
 
 	// SendBufferUtilization is called in the writePump after every successful
 	// write. used and capacity report the current send channel occupancy.
@@ -152,8 +152,8 @@ func (NoopCollector) MessageBroadcast(_ string, _ int, _ int) {}
 // MessageSent is a no-op. See MetricsCollector.MessageSent.
 func (NoopCollector) MessageSent(_, _ string, _ int) {}
 
-// FrameDropped is a no-op. See MetricsCollector.FrameDropped.
-func (NoopCollector) FrameDropped(_, _ string) {}
+// MessageDropped is a no-op. See MetricsCollector.MessageDropped.
+func (NoopCollector) MessageDropped(_, _ string) {}
 
 // SendBufferUtilization is a no-op. See MetricsCollector.SendBufferUtilization.
 func (NoopCollector) SendBufferUtilization(_, _ string, _, _ int) {}

--- a/metrics.go
+++ b/metrics.go
@@ -102,7 +102,7 @@ type MetricsCollector interface {
 	MessageDropped(roomID, connectionID string)
 
 	// SendBufferUtilization is called in the writePump after every successful
-	// write. used and capacity report the current send channel occupancy.
+	// write. used and capacity report the current send queue occupancy.
 	//
 	// This method is called once per message write. For high-throughput
 	// connections (e.g. 10k msg/s), expect the same call rate per connection.

--- a/metrics_hook_test.go
+++ b/metrics_hook_test.go
@@ -105,7 +105,7 @@ func TestMetricsCollector_MessageFlow(t *testing.T) {
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			connected <- struct{}{}
 		}),
-		wspulse.WithOnMessage(func(conn wspulse.Connection, f wspulse.Frame) {
+		wspulse.WithOnMessage(func(conn wspulse.Connection, f wspulse.Message) {
 			_ = srv.Broadcast(conn.RoomID(), f)
 			select {
 			case broadcastDone <- struct{}{}:
@@ -120,7 +120,7 @@ func TestMetricsCollector_MessageFlow(t *testing.T) {
 	_ = injectAndWait(t, srv, "conn-2", "metrics-room", connected)
 
 	// Inject a message from conn-1.
-	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "test"})
+	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Message{Event: "test"})
 	mt1.InjectMessage(wspulse.TextMessage, encoded)
 
 	requireReceive(t, broadcastDone)
@@ -180,9 +180,9 @@ func TestMetricsCollector_ResumeAttempt(t *testing.T) {
 	assert.Equal(t, 1, rec.countByName("ConnectionOpened"), "ConnectionOpened after resume (should not increment)")
 }
 
-// ── Metrics: frame dropped (send buffer full) ───────────────────────────────
+// ── Metrics: message dropped (send buffer full) ─────────────────────────────
 
-func TestMetricsCollector_FrameDropped_SendFull(t *testing.T) {
+func TestMetricsCollector_MessageDropped_SendFull(t *testing.T) {
 	t.Parallel()
 	rec := &recordingCollector{}
 	connected := make(chan wspulse.Connection, 1)
@@ -203,21 +203,21 @@ func TestMetricsCollector_FrameDropped_SendFull(t *testing.T) {
 	wspulse.InjectTransport(srv, "drop-conn", "drop-room", mt)
 	conn := requireReceive(t, connected)
 
-	frame := wspulse.Frame{Event: "fill", Payload: []byte(`{}`)}
+	msg := wspulse.Message{Event: "fill", Payload: []byte(`{}`)}
 	var gotBufferFull bool
 	for i := 0; i < 200; i++ {
-		if sendErr := conn.Send(frame); sendErr == wspulse.ErrSendBufferFull {
+		if sendErr := conn.Send(msg); sendErr == wspulse.ErrSendBufferFull {
 			gotBufferFull = true
 			break
 		}
 	}
 	require.True(t, gotBufferFull, "expected ErrSendBufferFull")
-	assert.GreaterOrEqual(t, rec.countByName("FrameDropped"), 1, "FrameDropped")
+	assert.GreaterOrEqual(t, rec.countByName("MessageDropped"), 1, "MessageDropped")
 }
 
-// ── Metrics: frame dropped (broadcast drop-oldest while suspended) ──────────
+// ── Metrics: message dropped (broadcast drop-oldest while suspended) ────────
 
-func TestMetricsCollector_FrameDropped_BroadcastDropOldest(t *testing.T) {
+func TestMetricsCollector_MessageDropped_BroadcastDropOldest(t *testing.T) {
 	t.Parallel()
 	rec := &recordingCollector{}
 	connected := make(chan struct{}, 1)
@@ -247,15 +247,15 @@ func TestMetricsCollector_FrameDropped_BroadcastDropOldest(t *testing.T) {
 
 	connectAndDrop(t, srv, "drop-conn", "drop-room", connected, dropped)
 
-	frame := wspulse.Frame{Event: "fill", Payload: []byte(`{}`)}
-	_ = srv.Broadcast("drop-room", frame) // fills ring buffer (size 1)
-	_ = srv.Broadcast("drop-room", frame) // triggers drop-oldest
+	msg := wspulse.Message{Event: "fill", Payload: []byte(`{}`)}
+	_ = srv.Broadcast("drop-room", msg) // fills ring buffer (size 1)
+	_ = srv.Broadcast("drop-room", msg) // triggers drop-oldest
 
-	// Poll for FrameDropped.
+	// Poll for MessageDropped.
 	deadline := time.Now().Add(time.Second)
-	for rec.countByName("FrameDropped") < 1 {
+	for rec.countByName("MessageDropped") < 1 {
 		if time.Now().After(deadline) {
-			require.Failf(t, "timed out", "FrameDropped=%d", rec.countByName("FrameDropped"))
+			require.Failf(t, "timed out", "MessageDropped=%d", rec.countByName("MessageDropped"))
 		}
 		time.Sleep(5 * time.Millisecond)
 	}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -30,7 +30,7 @@ func TestNoopCollector_AllMethodsCallable(t *testing.T) {
 	c.MessageReceived("room", 100)
 	c.MessageBroadcast("room", 100, 5)
 	c.MessageSent("room", "conn", 100)
-	c.FrameDropped("room", "conn")
+	c.MessageDropped("room", "conn")
 	c.SendBufferUtilization("room", "conn", 10, 256)
 	c.HeartbeatFailed("room", "conn")
 }
@@ -115,8 +115,8 @@ func (r *recordingCollector) MessageBroadcast(roomID string, sizeBytes int, fanO
 func (r *recordingCollector) MessageSent(roomID, connectionID string, sizeBytes int) {
 	r.record(metricsEvent{name: "MessageSent", roomID: roomID, connectionID: connectionID, sizeBytes: sizeBytes})
 }
-func (r *recordingCollector) FrameDropped(roomID, connectionID string) {
-	r.record(metricsEvent{name: "FrameDropped", roomID: roomID, connectionID: connectionID})
+func (r *recordingCollector) MessageDropped(roomID, connectionID string) {
+	r.record(metricsEvent{name: "MessageDropped", roomID: roomID, connectionID: connectionID})
 }
 func (r *recordingCollector) SendBufferUtilization(roomID, connectionID string, used, capacity int) {
 	r.record(metricsEvent{name: "SendBufferUtilization", roomID: roomID, connectionID: connectionID, used: used, capacity: capacity})

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -18,7 +18,7 @@ import (
 // function. This ensures tests never depend on real timeouts.
 type mockTransport struct {
 	readCh    chan readResult // test → readPump: inject messages or errors
-	writeCh   chan writeCall  // writePump → test: capture outbound frames
+	writeCh   chan writeCall  // writePump → test: capture outbound messages
 	closeCh   chan struct{}   // closed once on Close() or CloseNow()
 	closeOnce sync.Once
 

--- a/options.go
+++ b/options.go
@@ -116,7 +116,7 @@ func WithOnTransportDrop(fn func(Connection, error)) HubOption {
 // resume window.
 //
 // When this fires, OnConnect and OnDisconnect are NOT called — the session
-// continues as if the transport had never dropped. Buffered frames are replayed
+// continues as if the transport had never dropped. Buffered messages are replayed
 // to the new transport before the callback is invoked.
 //
 // This callback does NOT fire when:
@@ -170,7 +170,7 @@ func WithMaxMessageSize(n int64) HubOption {
 	return func(c *hubConfig) { c.maxMessageSize = n }
 }
 
-// WithSendBufferSize sets the per-connection outbound channel capacity (number of frames).
+// WithSendBufferSize sets the per-connection outbound channel capacity (number of messages).
 // n must be in [1, 4096].
 func WithSendBufferSize(n int) HubOption {
 	if n < 1 {

--- a/options.go
+++ b/options.go
@@ -10,10 +10,10 @@ import (
 
 // Configuration upper bounds — option functions panic if these ceilings are exceeded.
 const (
-	maxPingInterval  = 1 * time.Minute  // WithPingInterval upper bound
-	maxWriteTimeout  = 30 * time.Second // WithWriteTimeout upper bound
-	maxMsgSizeBytes  = 64 << 20         // WithMaxMessageSize upper bound — 64 MiB
-	maxSendBufFrames = 4096             // WithSendBufferSize upper bound
+	maxPingInterval    = 1 * time.Minute  // WithPingInterval upper bound
+	maxWriteTimeout    = 30 * time.Second // WithWriteTimeout upper bound
+	maxMsgSizeBytes    = 64 << 20         // WithMaxMessageSize upper bound — 64 MiB
+	maxSendBufMessages = 4096             // WithSendBufferSize upper bound
 )
 
 // ConnectFunc authenticates an incoming HTTP upgrade request and provides the
@@ -176,8 +176,8 @@ func WithSendBufferSize(n int) HubOption {
 	if n < 1 {
 		panic("wspulse: WithSendBufferSize: n must be at least 1")
 	}
-	if n > maxSendBufFrames {
-		panic(fmt.Sprintf("wspulse: WithSendBufferSize: n exceeds maximum (%d)", maxSendBufFrames))
+	if n > maxSendBufMessages {
+		panic(fmt.Sprintf("wspulse: WithSendBufferSize: n exceeds maximum (%d)", maxSendBufMessages))
 	}
 	return func(c *hubConfig) { c.sendBufferSize = n }
 }

--- a/options.go
+++ b/options.go
@@ -36,7 +36,7 @@ type HubOption func(*hubConfig) //nolint:revive
 type hubConfig struct {
 	connect            ConnectFunc
 	onConnect          func(Connection)
-	onMessage          func(Connection, Frame)
+	onMessage          func(Connection, Message)
 	onDisconnect       func(Connection, error)
 	onTransportDrop    func(Connection, error)
 	onTransportRestore func(Connection)
@@ -72,7 +72,7 @@ func WithOnConnect(fn func(Connection)) HubOption {
 	return func(c *hubConfig) { c.onConnect = fn }
 }
 
-// WithOnMessage registers a callback invoked for every inbound Frame received from
+// WithOnMessage registers a callback invoked for every inbound Message received from
 // a connected client. The callback is called from the connection's readPump goroutine
 // and must return quickly; use a goroutine for heavy work.
 //
@@ -80,7 +80,7 @@ func WithOnConnect(fn func(Connection)) HubOption {
 // On resume, the new readPump starts only after the old one has fully exited.
 // Handlers should still be safe for concurrent use when application code
 // accesses Connection from other goroutines (e.g. Send from an HTTP handler).
-func WithOnMessage(fn func(Connection, Frame)) HubOption {
+func WithOnMessage(fn func(Connection, Message)) HubOption {
 	return func(c *hubConfig) { c.onMessage = fn }
 }
 

--- a/options.go
+++ b/options.go
@@ -170,7 +170,7 @@ func WithMaxMessageSize(n int64) HubOption {
 	return func(c *hubConfig) { c.maxMessageSize = n }
 }
 
-// WithSendBufferSize sets the per-connection outbound channel capacity (number of messages).
+// WithSendBufferSize sets the per-connection outbound send buffer capacity (number of messages).
 // n must be in [1, 4096].
 func WithSendBufferSize(n int) HubOption {
 	if n < 1 {

--- a/send_queue.go
+++ b/send_queue.go
@@ -7,12 +7,12 @@ import (
 	"github.com/wspulse/hub/ring"
 )
 
-// sendQueue is a concurrent, fixed-capacity FIFO queue for outbound frames.
+// sendQueue is a concurrent, fixed-capacity FIFO queue for outbound messages.
 // It wraps a ring.Buffer[[]byte] with a mutex and condition variable
 // to provide a blocking Pop and two enqueue strategies:
 //
 //   - Enqueue: rejects when full (used by session.Send — caller should know)
-//   - ForceEnqueue: evicts the oldest frame when full (used by Broadcast)
+//   - ForceEnqueue: evicts the oldest message when full (used by Broadcast)
 //
 // This eliminates the TOCTOU race present in the previous three-select
 // drop-oldest pattern on session.send chan []byte.
@@ -103,7 +103,7 @@ func (q *sendQueue) Pop(ctx context.Context) ([]byte, error) {
 }
 
 // Drain removes and returns all items in FIFO order without blocking.
-// Used by the resume transition goroutine to transfer buffered frames into
+// Used by the resume transition goroutine to transfer buffered messages into
 // the new session's outbound send queue before its writePump starts.
 //
 // Must not be called concurrently with Pop.

--- a/send_queue_test.go
+++ b/send_queue_test.go
@@ -264,7 +264,7 @@ func TestSendQueue_F1_ConcurrentEnqueueNoRace(t *testing.T) {
 
 // TestSendQueue_F2_DropOldestIsAtomic is the critical regression test for
 // hub#44: verifies that drop-oldest enqueue in a concurrent scenario never
-// loses the newest frame. With the old three-select channel approach this
+// loses the newest message. With the old three-select channel approach this
 // test was intermittently flaky under -race.
 func TestSendQueue_F2_DropOldestIsAtomic(t *testing.T) {
 	t.Parallel()
@@ -312,7 +312,7 @@ func TestSendQueue_F2_DropOldestIsAtomic(t *testing.T) {
 				break
 			}
 		}
-		assert.True(t, newestFound, "newest frame must not be silently dropped")
+		assert.True(t, newestFound, "newest message must not be silently dropped")
 		assert.LessOrEqual(t, q.Len(), bufSize, "buffer must not exceed capacity")
 	}
 }

--- a/server.go
+++ b/server.go
@@ -14,12 +14,12 @@ import (
 type Hub interface {
 	http.Handler
 
-	// Send enqueues a Frame for the connection identified by connectionID.
+	// Send enqueues a Message for the connection identified by connectionID.
 	// Returns ErrConnectionNotFound if connectionID has no active connection.
-	Send(connectionID string, f Frame) error
+	Send(connectionID string, m Message) error
 
-	// Broadcast enqueues a Frame for every active connection in roomID.
-	Broadcast(roomID string, f Frame) error
+	// Broadcast enqueues a Message for every active connection in roomID.
+	Broadcast(roomID string, m Message) error
 
 	// Kick forcefully closes the connection identified by connectionID.
 	// Kick always bypasses the resume window — the session is destroyed
@@ -155,24 +155,24 @@ func (s *internalHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Send enqueues a Frame for the connection identified by connectionID.
-func (s *internalHub) Send(connectionID string, f Frame) error {
+// Send enqueues a Message for the connection identified by connectionID.
+func (s *internalHub) Send(connectionID string, m Message) error {
 	target := s.heart.get(connectionID)
 	if target == nil {
 		return ErrConnectionNotFound
 	}
-	return target.Send(f)
+	return target.Send(m)
 }
 
-// Broadcast enqueues a Frame for every active connection in roomID.
-func (s *internalHub) Broadcast(roomID string, f Frame) error {
+// Broadcast enqueues a Message for every active connection in roomID.
+func (s *internalHub) Broadcast(roomID string, m Message) error {
 	select {
 	case <-s.heart.done:
 		return ErrHubClosed
 	default:
 	}
 
-	data, err := s.config.codec.Encode(f)
+	data, err := s.config.codec.Encode(m)
 	if err != nil {
 		s.config.logger.Warn("wspulse: broadcast encode failed",
 			zap.String("room_id", roomID),

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -86,11 +86,11 @@ func benchBroadcast(b *testing.B, roomSize int) {
 		}
 	}
 
-	frame := wspulse.Frame{Event: "bench", Payload: []byte(`{"v":1}`)}
+	msg := wspulse.Message{Event: "bench", Payload: []byte(`{"v":1}`)}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := srv.Broadcast("bench-room", frame); err != nil {
+		if err := srv.Broadcast("bench-room", msg); err != nil {
 			b.Fatalf("Broadcast: %v", err)
 		}
 	}
@@ -142,14 +142,14 @@ func BenchmarkSend(b *testing.B) {
 		}
 	}()
 
-	frame := wspulse.Frame{Event: "bench", Payload: []byte(`{"v":1}`)}
+	msg := wspulse.Message{Event: "bench", Payload: []byte(`{"v":1}`)}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// ErrSendBufferFull is expected at benchmark speed — the drain
 		// goroutine cannot keep up with the enqueue rate. The benchmark
 		// measures raw encode+enqueue cost including both paths.
-		_ = conn.Send(frame)
+		_ = conn.Send(msg)
 	}
 }
 
@@ -192,15 +192,15 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 	// Do NOT drain — let buffer fill so broadcast hits drop-oldest path.
 	// Pre-fill the send buffer via direct Send (bypasses hub, synchronous
 	// enqueue) to avoid a racy sleep.
-	frame := wspulse.Frame{Event: "bench", Payload: []byte(`{"v":1}`)}
-	if err := conn.Send(frame); err != nil {
+	msg := wspulse.Message{Event: "bench", Payload: []byte(`{"v":1}`)}
+	if err := conn.Send(msg); err != nil {
 		b.Fatalf("prefill Send failed: %v", err)
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := srv.Broadcast("bench-room", frame); err != nil {
+		if err := srv.Broadcast("bench-room", msg); err != nil {
 			b.Fatalf("Broadcast failed: %v", err)
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -25,7 +25,7 @@ func TestHub_Send_ErrConnectionNotFound(t *testing.T) {
 	t.Parallel()
 	srv := wspulse.NewHub(acceptAll)
 	t.Cleanup(srv.Close)
-	err := srv.Send("does-not-exist", wspulse.Frame{Event: "ping"})
+	err := srv.Send("does-not-exist", wspulse.Message{Event: "ping"})
 	require.ErrorIs(t, err, wspulse.ErrConnectionNotFound)
 }
 
@@ -170,7 +170,7 @@ func TestHub_Broadcast_EmptyRoom_NoError(t *testing.T) {
 	t.Parallel()
 	srv := wspulse.NewHub(acceptAll)
 	t.Cleanup(srv.Close)
-	err := srv.Broadcast("nonexistent-room", wspulse.Frame{Event: "msg"})
+	err := srv.Broadcast("nonexistent-room", wspulse.Message{Event: "msg"})
 	require.NoError(t, err)
 }
 
@@ -190,7 +190,7 @@ func TestHub_Send_AfterClose_ReturnsErrConnectionNotFound(t *testing.T) {
 	srv := wspulse.NewHub(acceptAll)
 	srv.Close()
 	// After close, hub maps are empty — returns ErrConnectionNotFound.
-	err := srv.Send("any", wspulse.Frame{Event: "x"})
+	err := srv.Send("any", wspulse.Message{Event: "x"})
 	require.ErrorIs(t, err, wspulse.ErrConnectionNotFound)
 }
 
@@ -200,7 +200,7 @@ func TestHub_Broadcast_AfterClose(t *testing.T) {
 	t.Parallel()
 	srv := wspulse.NewHub(acceptAll)
 	srv.Close()
-	err := srv.Broadcast("test-room", wspulse.Frame{Event: "hello"})
+	err := srv.Broadcast("test-room", wspulse.Message{Event: "hello"})
 	require.ErrorIs(t, err, wspulse.ErrHubClosed)
 }
 

--- a/session.go
+++ b/session.go
@@ -240,7 +240,7 @@ func (s *session) Close() error {
 // drain so that concurrent Send() calls continue buffering to resumeBuffer.
 // The drain loop runs until resumeBuffer is empty, then atomically flips the
 // state to stateConnected under the same lock acquisition. This ensures
-// all pre-resume frames precede post-resume frames in s.send.
+// all pre-resume messages precede post-resume messages in s.send.
 //
 // Must be called from the heart's event loop (single-goroutine serialization).
 func (s *session) attachWS(trans transport, h *heart, onResumeComplete func()) {

--- a/session.go
+++ b/session.go
@@ -25,9 +25,9 @@ type Connection interface {
 	// RoomID returns the room this connection belongs to, as provided by ConnectFunc.
 	RoomID() string
 
-	// Send enqueues f for delivery to the remote peer.
+	// Send enqueues m for delivery to the remote peer.
 	// Returns ErrConnectionClosed or ErrSendBufferFull on failure.
-	Send(f Frame) error
+	Send(m Message) error
 
 	// Close initiates a graceful shutdown of the session.
 	Close() error
@@ -56,8 +56,8 @@ const (
 //   - session.send is shared across reconnects — it persists for the session lifetime.
 //
 // Goroutine ownership:
-//   - readPump  : reads from transport, forwards decoded Frames to onMessage.
-//   - writePump : sole writer of application data frames on transport; drains session.send.
+//   - readPump  : reads from transport, forwards decoded Messages to onMessage.
+//   - writePump : sole writer of application data on transport; drains session.send.
 //   - pingPump  : drives Ping heartbeat; fires HeartbeatFailed metric on failure.
 //
 // Lifecycle signal flow:
@@ -67,7 +67,7 @@ const (
 type session struct {
 	id     string
 	roomID string
-	send   *sendQueue    // outbound frame queue; shared across reconnects
+	send   *sendQueue    // outbound message queue; shared across reconnects
 	done   chan struct{} // closed once to signal session termination; guarded by closeOnce
 
 	mu           sync.Mutex           // guards transport, pumpCancel, pumpDone, graceTimer, state, resumeBuffer, suspendEpoch
@@ -89,14 +89,14 @@ func (s *session) ID() string            { return s.id }
 func (s *session) RoomID() string        { return s.roomID }
 func (s *session) Done() <-chan struct{} { return s.done }
 
-// Send encodes f and enqueues the bytes for delivery to the remote peer.
-// If the session is suspended (within resume window), the frame is buffered
+// Send encodes m and enqueues the bytes for delivery to the remote peer.
+// If the session is suspended (within resume window), the message is buffered
 // to the resume ring buffer instead of the outbound send queue.
 //
 // The select is a fast-path optimisation: skip encoding when the session is
 // already closed. The authoritative closed check is sendQueue.Enqueue, which
 // inspects q.closed under the queue mutex.
-func (s *session) Send(f Frame) error {
+func (s *session) Send(m Message) error {
 	// Fast path: bail early if the session is already closed.
 	select {
 	case <-s.done:
@@ -104,7 +104,7 @@ func (s *session) Send(f Frame) error {
 	default:
 	}
 
-	data, err := s.config.codec.Encode(f)
+	data, err := s.config.codec.Encode(m)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (s *session) Send(f Frame) error {
 // the session state. Used by both Send (after encoding) and the hub's
 // broadcast path (which pre-encodes once for all connections).
 //
-// When dropOldest is true and the send buffer is full, the oldest frame
+// When dropOldest is true and the send buffer is full, the oldest message
 // in the buffer is discarded to make room for data. This is the
 // backpressure strategy used by Broadcast. When false, ErrSendBufferFull
 // is returned immediately (the strategy used by Send).
@@ -127,12 +127,12 @@ func (s *session) enqueue(data []byte, dropOldest bool) error {
 		dropped := s.resumeBuffer.ForcePush(data)
 		s.mu.Unlock()
 		if dropped {
-			s.config.metrics.FrameDropped(s.roomID, s.id)
-			s.config.logger.Debug("wspulse: oldest frame dropped from resumeBuffer (backpressure)",
+			s.config.metrics.MessageDropped(s.roomID, s.id)
+			s.config.logger.Debug("wspulse: oldest message dropped from resumeBuffer (backpressure)",
 				zap.String("conn_id", s.id),
 			)
 		} else {
-			s.config.logger.Debug("wspulse: frame buffered to resumeBuffer",
+			s.config.logger.Debug("wspulse: message buffered to resumeBuffer",
 				zap.String("conn_id", s.id),
 			)
 		}
@@ -146,20 +146,20 @@ func (s *session) enqueue(data []byte, dropOldest bool) error {
 			return err
 		}
 		if evicted {
-			s.config.logger.Debug("wspulse: oldest frame dropped from send buffer (backpressure)",
+			s.config.logger.Debug("wspulse: oldest message dropped from send buffer (backpressure)",
 				zap.String("conn_id", s.id),
 			)
-			s.config.metrics.FrameDropped(s.roomID, s.id)
+			s.config.metrics.MessageDropped(s.roomID, s.id)
 		}
 		return nil
 	}
 
 	err := s.send.Enqueue(data)
 	if err == ErrSendBufferFull {
-		s.config.logger.Debug("wspulse: send buffer full, dropping frame",
+		s.config.logger.Debug("wspulse: send buffer full, dropping message",
 			zap.String("conn_id", s.id),
 		)
-		s.config.metrics.FrameDropped(s.roomID, s.id)
+		s.config.metrics.MessageDropped(s.roomID, s.id)
 	}
 	return err
 }
@@ -236,7 +236,7 @@ func (s *session) Close() error {
 //     stateSuspended (during the drain phase), which would leave the
 //     session in a zombie state — stateConnected with no active pumps.
 //
-// Frame ordering guarantee: the state remains stateSuspended during the
+// Message ordering guarantee: the state remains stateSuspended during the
 // drain so that concurrent Send() calls continue buffering to resumeBuffer.
 // The drain loop runs until resumeBuffer is empty, then atomically flips the
 // state to stateConnected under the same lock acquisition. This ensures
@@ -324,12 +324,12 @@ func (s *session) attachWS(trans transport, h *heart, onResumeComplete func()) {
 						break
 					}
 					if evicted {
-						s.config.logger.Debug("wspulse: oldest frame dropped to make room for resume frame",
+						s.config.logger.Debug("wspulse: oldest message dropped to make room for resume message",
 							zap.String("conn_id", s.id),
 						)
-						s.config.metrics.FrameDropped(s.roomID, s.id)
+						s.config.metrics.MessageDropped(s.roomID, s.id)
 					} else {
-						s.config.logger.Debug("wspulse: resume frame enqueued",
+						s.config.logger.Debug("wspulse: resume message enqueued",
 							zap.String("conn_id", s.id),
 						)
 					}
@@ -500,12 +500,12 @@ func (s *session) readPump(ctx context.Context, trans transport, h *heart) {
 		}
 		s.config.metrics.MessageReceived(s.roomID, len(data))
 		if fn := s.config.onMessage; fn != nil {
-			frame, decodeErr := s.config.codec.Decode(data)
+			msg, decodeErr := s.config.codec.Decode(data)
 			if decodeErr != nil {
 				s.config.logger.Warn("wspulse: decode failed", zap.String("conn_id", s.id), zap.Error(decodeErr))
 				continue
 			}
-			fn(s, frame)
+			fn(s, msg)
 		}
 	}
 }
@@ -575,7 +575,7 @@ func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan 
 		}
 
 		writeCtx, cancel := context.WithTimeout(ctx, s.config.writeTimeout)
-		err = trans.Write(writeCtx, s.config.codec.FrameType(), data)
+		err = trans.Write(writeCtx, s.config.codec.WireType(), data)
 		cancel()
 		if err != nil {
 			if ctx.Err() != nil {

--- a/session.go
+++ b/session.go
@@ -215,7 +215,7 @@ func (s *session) Close() error {
 
 // attachWS sets the physical WebSocket connection for this session and
 // spawns readPump + writePump + pingPump goroutines. If the session was
-// suspended, buffered frames are drained into the send channel before the
+// suspended, buffered messages are drained into the send queue before the
 // new pumps start.
 //
 // onResumeComplete, if non-nil, is invoked in a separate goroutine after
@@ -229,9 +229,9 @@ func (s *session) Close() error {
 // This avoids three problems:
 //   - The heart event loop being blocked for up to writeTimeout while waiting
 //     for the old writePump to finish.
-//   - Resume-buffer frames being drained into s.send while the old
+//   - Resume-buffer messages being drained into s.send while the old
 //     writePump is still alive, which could cause the old pump to consume
-//     and lose those frames by writing them to the dead WebSocket.
+//     and lose those messages by writing them to the dead WebSocket.
 //   - readPump reporting a transportDied while the session is still in
 //     stateSuspended (during the drain phase), which would leave the
 //     session in a zombie state — stateConnected with no active pumps.
@@ -277,9 +277,9 @@ func (s *session) attachWS(trans transport, h *heart, onResumeComplete func()) {
 	// Transition goroutine: wait for the old writePump to exit, drain
 	// the resume buffer, and start the new pump group. This guarantees:
 	// 1. Only one writePump drains s.send at a time.
-	// 2. Resume-buffer frames enter s.send only after the old pump is gone.
+	// 2. Resume-buffer messages enter s.send only after the old pump is gone.
 	// 3. The heart event loop is never blocked.
-	// 4. All buffered frames precede frames sent after the state flip.
+	// 4. All buffered messages precede messages sent after the state flip.
 	// 5. readPump only runs when state is stateConnected, preventing
 	//    transportDied messages from arriving during stateSuspended.
 	go func() {
@@ -299,8 +299,8 @@ func (s *session) attachWS(trans transport, h *heart, onResumeComplete func()) {
 				zap.Int("buffered", bufferedCount),
 			)
 			for {
-				frames := buffer.Drain()
-				if len(frames) == 0 {
+				messages := buffer.Drain()
+				if len(messages) == 0 {
 					// Guard: if Close() was called concurrently, do not
 					// overwrite stateClosed with stateConnected.
 					if s.state != stateClosed {
@@ -314,7 +314,7 @@ func (s *session) attachWS(trans transport, h *heart, onResumeComplete func()) {
 					break
 				}
 				s.mu.Unlock()
-				for _, data := range frames {
+				for _, data := range messages {
 					evicted, err := s.send.ForceEnqueue(data)
 					if err != nil {
 						// Queue closed — session terminated during drain.

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -28,7 +28,7 @@ func TestReadPumpPanicRecovery(t *testing.T) {
 	disconnected := make(chan struct{}, 1)
 	srv := wspulse.NewHub(
 		acceptAll,
-		wspulse.WithOnMessage(func(_ wspulse.Connection, _ wspulse.Frame) {
+		wspulse.WithOnMessage(func(_ wspulse.Connection, _ wspulse.Message) {
 			panic("boom")
 		}),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
@@ -43,7 +43,7 @@ func TestReadPumpPanicRecovery(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// Inject a message that triggers the panic in OnMessage.
-	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
+	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Message{Event: "trigger"})
 	mt.InjectMessage(wspulse.TextMessage, encoded)
 
 	requireReceive(t, disconnected)
@@ -55,7 +55,7 @@ func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
 	disconnectErr := make(chan error, 1)
 	srv := wspulse.NewHub(
 		acceptAll,
-		wspulse.WithOnMessage(func(_ wspulse.Connection, _ wspulse.Frame) {
+		wspulse.WithOnMessage(func(_ wspulse.Connection, _ wspulse.Message) {
 			panic("typed-boom")
 		}),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
@@ -69,7 +69,7 @@ func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
-	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "trigger"})
+	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Message{Event: "trigger"})
 	mt.InjectMessage(wspulse.TextMessage, encoded)
 
 	got := requireReceive(t, disconnectErr)
@@ -80,18 +80,18 @@ func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
 	assert.Equal(t, "wspulse: onMessage panic: typed-boom", pe.Error())
 }
 
-// ── ReadPump malformed frame ────────────────────────────────────────────────
+// ── ReadPump malformed message ──────────────────────────────────────────────
 
 func TestReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
 	t.Parallel()
 	connected := make(chan struct{}, 1)
-	received := make(chan wspulse.Frame, 2)
+	received := make(chan wspulse.Message, 2)
 	srv := wspulse.NewHub(
 		acceptAll,
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			connected <- struct{}{}
 		}),
-		wspulse.WithOnMessage(func(_ wspulse.Connection, f wspulse.Frame) {
+		wspulse.WithOnMessage(func(_ wspulse.Connection, f wspulse.Message) {
 			received <- f
 		}),
 	)
@@ -99,11 +99,11 @@ func TestReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
 
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
-	// Inject malformed frame (not valid JSON).
+	// Inject malformed message (not valid JSON).
 	mt.InjectMessage(wspulse.TextMessage, []byte("not-json"))
 
-	// Inject valid frame after the malformed one.
-	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "valid"})
+	// Inject valid message after the malformed one.
+	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Message{Event: "valid"})
 	mt.InjectMessage(wspulse.TextMessage, encoded)
 
 	f := requireReceive(t, received)
@@ -134,18 +134,18 @@ func TestBroadcastDropsOldest_SlowClient(t *testing.T) {
 		if i == totalBroadcasts-1 {
 			typ = "newest"
 		}
-		_ = srv.Broadcast("test-room", wspulse.Frame{Event: typ, Payload: []byte(`"x"`)})
+		_ = srv.Broadcast("test-room", wspulse.Message{Event: typ, Payload: []byte(`"x"`)})
 	}
-	_ = srv.Broadcast("test-room", wspulse.Frame{Event: "done"})
+	_ = srv.Broadcast("test-room", wspulse.Message{Event: "done"})
 
 	// Read from mock transport until sentinel.
-	var frames []wspulse.Frame
+	var messages []wspulse.Message
 	for {
 		w, ok := mt.WaitWrite(time.Second)
 		if !ok {
-			require.Fail(t, "timed out waiting for frames")
+			require.Fail(t, "timed out waiting for messages")
 		}
-		// Skip ping frames.
+		// Skip ping frames (WebSocket protocol-level).
 		if w.messageType != wspulse.TextMessage {
 			continue
 		}
@@ -156,18 +156,18 @@ func TestBroadcastDropsOldest_SlowClient(t *testing.T) {
 		if f.Event == "done" {
 			break
 		}
-		frames = append(frames, f)
+		messages = append(messages, f)
 	}
 
-	require.NotEmpty(t, frames)
+	require.NotEmpty(t, messages)
 	found := false
-	for _, f := range frames {
+	for _, f := range messages {
 		if f.Event == "newest" {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "newest frame not found; drop-oldest did not preserve it")
+	assert.True(t, found, "newest message not found; drop-oldest did not preserve it")
 }
 
 // ── Concurrent broadcast ────────────────────────────────────────────────────
@@ -199,7 +199,7 @@ func TestConcurrentBroadcast_NoRace(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < messagesPerWorker; j++ {
-				_ = srv.Broadcast("room", wspulse.Frame{Event: "ping"})
+				_ = srv.Broadcast("room", wspulse.Message{Event: "ping"})
 			}
 		}()
 	}
@@ -260,7 +260,7 @@ func TestConcurrentCloseAndBroadcast_NoRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
-			_ = srv.Broadcast("test-room", wspulse.Frame{Event: "msg"})
+			_ = srv.Broadcast("test-room", wspulse.Message{Event: "msg"})
 		}
 	}()
 	go func() {
@@ -319,7 +319,7 @@ func TestConnectionSend_AfterClose_ReturnsErrConnectionClosed(t *testing.T) {
 	mt.InjectError(errors.New("closed"))
 	requireReceive(t, disconnected)
 
-	err := conn.Send(wspulse.Frame{Event: "after-close"})
+	err := conn.Send(wspulse.Message{Event: "after-close"})
 	assert.ErrorIs(t, err, wspulse.ErrConnectionClosed)
 }
 
@@ -345,7 +345,7 @@ func TestBroadcast_SkipsClosedSession(t *testing.T) {
 	requireReceive(t, disconnected)
 
 	// Broadcast to the room — should not panic or error despite closed session.
-	err := srv.Broadcast("test-room", wspulse.Frame{Event: "after-close"})
+	err := srv.Broadcast("test-room", wspulse.Message{Event: "after-close"})
 	require.NoError(t, err)
 }
 
@@ -385,15 +385,15 @@ func TestGetConnections_EmptyAfterDisconnect(t *testing.T) {
 // failingCodec always returns an error on Encode.
 type failingCodec struct{}
 
-func (failingCodec) Encode(wspulse.Frame) ([]byte, error) {
+func (failingCodec) Encode(wspulse.Message) ([]byte, error) {
 	return nil, errors.New("codec: encode failed")
 }
 
-func (failingCodec) Decode(data []byte) (wspulse.Frame, error) {
+func (failingCodec) Decode(data []byte) (wspulse.Message, error) {
 	return wspulse.JSONCodec.Decode(data)
 }
 
-func (failingCodec) FrameType() core.MessageType { return core.TextMessage }
+func (failingCodec) WireType() core.MessageType { return core.TextMessage }
 
 func TestBroadcast_EncodeError_ReturnsError(t *testing.T) {
 	t.Parallel()
@@ -409,7 +409,7 @@ func TestBroadcast_EncodeError_ReturnsError(t *testing.T) {
 
 	_ = injectAndWait(t, srv, "test-connection", "test-room", connected)
 
-	err := srv.Broadcast("test-room", wspulse.Frame{Event: "test"})
+	err := srv.Broadcast("test-room", wspulse.Message{Event: "test"})
 	assert.Error(t, err)
 }
 
@@ -429,7 +429,7 @@ func TestConnectionSend_EncodeError_ReturnsError(t *testing.T) {
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt)
 	conn := requireReceive(t, connected)
 
-	err := conn.Send(wspulse.Frame{Event: "test"})
+	err := conn.Send(wspulse.Message{Event: "test"})
 	assert.Error(t, err)
 }
 
@@ -454,7 +454,7 @@ func TestNoOnMessage_ReadPumpStillProcesses(t *testing.T) {
 	mt := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// Send a message — readPump should process it without error even with no OnMessage.
-	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "ignored"})
+	encoded, _ := wspulse.JSONCodec.Encode(wspulse.Message{Event: "ignored"})
 	mt.InjectMessage(wspulse.TextMessage, encoded)
 
 	// Then kill the transport.
@@ -550,7 +550,7 @@ func TestConnectionSend_DoneClosesDuringEnqueue(t *testing.T) {
 	requireReceive(t, disconnected)
 
 	// Send after done is closed.
-	err := conn.Send(wspulse.Frame{Event: "late"})
+	err := conn.Send(wspulse.Message{Event: "late"})
 	assert.ErrorIs(t, err, wspulse.ErrConnectionClosed)
 }
 

--- a/session_misc_test.go
+++ b/session_misc_test.go
@@ -82,7 +82,7 @@ func TestReadPumpPanic_ErrorsAsPanicError(t *testing.T) {
 
 // ── ReadPump malformed message ──────────────────────────────────────────────
 
-func TestReadPump_MalformedFrame_DropsAndContinues(t *testing.T) {
+func TestReadPump_MalformedMessage_DropsAndContinues(t *testing.T) {
 	t.Parallel()
 	connected := make(chan struct{}, 1)
 	received := make(chan wspulse.Message, 2)

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -88,8 +88,8 @@ func TestResume_ReconnectWithinWindow(t *testing.T) {
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 
 	// Verify the resumed connection is reachable.
-	frame := wspulse.Frame{Event: "after-resume", Payload: []byte(`"ok"`)}
-	require.NoError(t, srv.Send("test-connection", frame))
+	msg := wspulse.Message{Event: "after-resume", Payload: []byte(`"ok"`)}
+	require.NoError(t, srv.Send("test-connection", msg))
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected write to resumed connection")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -149,9 +149,9 @@ func TestResume_GraceExpires_FiresOnDisconnect(t *testing.T) {
 	requireReceive(t, disconnected)
 }
 
-// ── Resume: buffered frames delivered ───────────────────────────────────────
+// ── Resume: buffered messages delivered ─────────────────────────────────────
 
-func TestResume_BufferedFramesDelivered(t *testing.T) {
+func TestResume_BufferedMessagesDelivered(t *testing.T) {
 	t.Parallel()
 	connected := make(chan struct{}, 2)
 	dropped := make(chan struct{}, 1)
@@ -183,9 +183,9 @@ func TestResume_BufferedFramesDelivered(t *testing.T) {
 
 	connectAndDrop(t, srv, "test-connection", "test-room", connected, dropped)
 
-	// Send frames while suspended — they go to ring buffer.
+	// Send messages while suspended — they go to ring buffer.
 	for i := 0; i < 3; i++ {
-		_ = srv.Send("test-connection", wspulse.Frame{
+		_ = srv.Send("test-connection", wspulse.Message{
 			Event:   "buffered",
 			Payload: []byte(`"` + string(rune('a'+i)) + `"`),
 		})
@@ -193,17 +193,17 @@ func TestResume_BufferedFramesDelivered(t *testing.T) {
 
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 
-	// Read all 3 buffered frames.
-	var frames []wspulse.Frame
+	// Read all 3 buffered messages.
+	var messages []wspulse.Message
 	for i := 0; i < 3; i++ {
 		w, ok := mt2.WaitWrite(time.Second)
-		require.True(t, ok, "expected buffered frame %d", i)
+		require.True(t, ok, "expected buffered message %d", i)
 		f, err := wspulse.JSONCodec.Decode(w.data)
 		require.NoError(t, err)
-		frames = append(frames, f)
+		messages = append(messages, f)
 	}
-	require.Len(t, frames, 3)
-	for _, f := range frames {
+	require.Len(t, messages, 3)
+	for _, f := range messages {
 		assert.Equal(t, "buffered", f.Event)
 	}
 }
@@ -353,14 +353,14 @@ func TestResume_BroadcastWhileSuspended(t *testing.T) {
 
 	connectAndDrop(t, srv, "test-connection", "test-room", connected, dropped)
 
-	// Broadcast while suspended — frames go to ring buffer.
-	require.NoError(t, srv.Broadcast("test-room", wspulse.Frame{Event: "suspended-broadcast"}))
+	// Broadcast while suspended — messages go to ring buffer.
+	require.NoError(t, srv.Broadcast("test-room", wspulse.Message{Event: "suspended-broadcast"}))
 
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 
 	// Buffered broadcast should be delivered.
 	w, ok := mt2.WaitWrite(time.Second)
-	require.True(t, ok, "expected buffered broadcast frame")
+	require.True(t, ok, "expected buffered broadcast message")
 	f, err := wspulse.JSONCodec.Decode(w.data)
 	require.NoError(t, err)
 	assert.Equal(t, "suspended-broadcast", f.Event)
@@ -605,7 +605,7 @@ func TestResume_ConcurrentBroadcastDuringResume_NoRace(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 50; j++ {
-				_ = srv.Broadcast("test-room", wspulse.Frame{Event: "ping"})
+				_ = srv.Broadcast("test-room", wspulse.Message{Event: "ping"})
 			}
 		}()
 	}
@@ -671,7 +671,7 @@ func TestResume_StaleClosedSession_Reconnect(t *testing.T) {
 	mt2 := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// Verify the new connection works.
-	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "alive"}))
+	require.NoError(t, srv.Send("test-connection", wspulse.Message{Event: "alive"}))
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected write to new connection")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -896,7 +896,7 @@ func TestResume_WritePumpStopsOnContextCancellation(t *testing.T) {
 	mt1 := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// Send data before closing to ensure writePump is active.
-	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "pre-suspend"}))
+	require.NoError(t, srv.Send("test-connection", wspulse.Message{Event: "pre-suspend"}))
 	w, ok := mt1.WaitWrite(time.Second)
 	require.True(t, ok, "expected pre-suspend write")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -911,7 +911,7 @@ func TestResume_WritePumpStopsOnContextCancellation(t *testing.T) {
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 
 	// If old writePump didn't exit via context cancellation, the new pump wouldn't start.
-	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "post-resume"}))
+	require.NoError(t, srv.Send("test-connection", wspulse.Message{Event: "post-resume"}))
 	w2, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected post-resume write")
 	f2, err := wspulse.JSONCodec.Decode(w2.data)
@@ -963,7 +963,7 @@ func TestResume_WritePumpExitsViaContextCancellation(t *testing.T) {
 	// Reconnect to prove the old writePump has exited correctly.
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 
-	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "verify"}))
+	require.NoError(t, srv.Send("test-connection", wspulse.Message{Event: "verify"}))
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected verify write")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -1021,7 +1021,7 @@ func TestResume_ConnectionCloseWhileSuspended_ThenReconnect(t *testing.T) {
 	mt2 := injectAndWait(t, srv, "test-connection", "test-room", connected)
 
 	// Verify new session works.
-	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "after-stale"}))
+	require.NoError(t, srv.Send("test-connection", wspulse.Message{Event: "after-stale"}))
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected write to new connection")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -1080,7 +1080,7 @@ func TestResume_StaleClosedSession_OnDisconnectFires(t *testing.T) {
 	requireReceive(t, disconnected)
 
 	// Verify new session works.
-	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "alive"}))
+	require.NoError(t, srv.Send("test-connection", wspulse.Message{Event: "alive"}))
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected write to new connection")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -1130,11 +1130,11 @@ func TestResume_DrainBufferFull(t *testing.T) {
 
 	connectAndDrop(t, srv, "test-connection", "test-room", connected, dropped)
 
-	// Send multiple frames while suspended — they go to the resume buffer.
-	// With send buffer size 1, draining 3 frames overflows the send channel
+	// Send multiple messages while suspended — they go to the resume buffer.
+	// With send buffer size 1, draining 3 messages overflows the send channel
 	// and triggers the drop-oldest backpressure in the drain loop.
 	for i := 0; i < 3; i++ {
-		_ = srv.Send("test-connection", wspulse.Frame{
+		_ = srv.Send("test-connection", wspulse.Message{
 			Event:   "buffered",
 			Payload: []byte(`"` + string(rune('a'+i)) + `"`),
 		})
@@ -1143,9 +1143,9 @@ func TestResume_DrainBufferFull(t *testing.T) {
 	// Reconnect — the transition goroutine drains the resume buffer.
 	mt2 := reconnect(t, srv, "test-connection", "test-room", restored)
 
-	// Read at least one frame to verify the session is functional.
+	// Read at least one message to verify the session is functional.
 	w, ok := mt2.WaitWrite(time.Second)
-	require.True(t, ok, "expected at least one buffered frame")
+	require.True(t, ok, "expected at least one buffered message")
 	f, err := wspulse.JSONCodec.Decode(w.data)
 	require.NoError(t, err)
 	assert.Equal(t, "buffered", f.Event)
@@ -1534,9 +1534,9 @@ func TestResume_GraceTimerFiresAfterReconnect(t *testing.T) {
 	// so handleGraceExpired should skip it.
 	fc.Fire(0)
 
-	// Verify session is still alive by round-tripping a frame.
-	frame := wspulse.Frame{Event: "still-alive", Payload: []byte(`"ok"`)}
-	require.NoError(t, srv.Send("test-connection", frame))
+	// Verify session is still alive by round-tripping a message.
+	msg := wspulse.Message{Event: "still-alive", Payload: []byte(`"ok"`)}
+	require.NoError(t, srv.Send("test-connection", msg))
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected write after grace timer expired")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -1606,8 +1606,8 @@ func TestResume_StaleGraceTimer(t *testing.T) {
 	fc.Fire(0)
 	fc.Fire(1)
 
-	// Verify session is still alive by round-tripping a frame.
-	require.NoError(t, srv.Send("test-connection", wspulse.Frame{Event: "alive"}))
+	// Verify session is still alive by round-tripping a message.
+	require.NoError(t, srv.Send("test-connection", wspulse.Message{Event: "alive"}))
 	w, ok := mt3.WaitWrite(time.Second)
 	require.True(t, ok, "expected write after stale timers")
 	f, err := wspulse.JSONCodec.Decode(w.data)
@@ -1760,7 +1760,7 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 		wspulse.WithOnTransportRestore(func(_ wspulse.Connection) {
 			events <- "restore"
 		}),
-		wspulse.WithOnMessage(func(_ wspulse.Connection, _ wspulse.Frame) {
+		wspulse.WithOnMessage(func(_ wspulse.Connection, _ wspulse.Message) {
 			events <- "message"
 		}),
 	)
@@ -1777,7 +1777,7 @@ func TestOnTransportRestore_ThenOnMessage(t *testing.T) {
 	require.Equal(t, "restore", e, "first event after reconnect")
 
 	// Now send a message on the new transport.
-	encoded, err := wspulse.JSONCodec.Encode(wspulse.Frame{Event: "ping"})
+	encoded, err := wspulse.JSONCodec.Encode(wspulse.Message{Event: "ping"})
 	require.NoError(t, err)
 	mt2.InjectMessage(wspulse.TextMessage, encoded)
 
@@ -1808,10 +1808,10 @@ func TestOnTransportRestore_FiresAfterStateConnected(t *testing.T) {
 			}
 		}),
 		wspulse.WithOnTransportRestore(func(c wspulse.Connection) {
-			// Send a frame from within the callback. If this fires
-			// before stateConnected, the frame goes to the resume
+			// Send a message from within the callback. If this fires
+			// before stateConnected, the message goes to the resume
 			// buffer (already drained) and never reaches the client.
-			_ = c.Send(wspulse.Frame{
+			_ = c.Send(wspulse.Message{
 				Event:   "from-restore",
 				Payload: []byte(`"hello"`),
 			})
@@ -1825,7 +1825,7 @@ func TestOnTransportRestore_FiresAfterStateConnected(t *testing.T) {
 	mt2 := newMockTransport()
 	wspulse.InjectTransport(srv, "test-connection", "test-room", mt2)
 
-	// The client must receive the frame sent from OnTransportRestore.
+	// The client must receive the message sent from OnTransportRestore.
 	w, ok := mt2.WaitWrite(time.Second)
 	require.True(t, ok, "expected write from OnTransportRestore callback")
 	f, err := wspulse.JSONCodec.Decode(w.data)

--- a/session_resume_test.go
+++ b/session_resume_test.go
@@ -1131,7 +1131,7 @@ func TestResume_DrainBufferFull(t *testing.T) {
 	connectAndDrop(t, srv, "test-connection", "test-room", connected, dropped)
 
 	// Send multiple messages while suspended — they go to the resume buffer.
-	// With send buffer size 1, draining 3 messages overflows the send channel
+	// With send buffer size 1, draining 3 messages overflows the send buffer
 	// and triggers the drop-oldest backpressure in the drain loop.
 	for i := 0; i < 3; i++ {
 		_ = srv.Send("test-connection", wspulse.Message{

--- a/types.go
+++ b/types.go
@@ -2,10 +2,10 @@ package wspulse
 
 import core "github.com/wspulse/core"
 
-// Frame is the minimal transport unit for WebSocket communication.
-type Frame = core.Frame
+// Message is the minimal transport unit for WebSocket communication.
+type Message = core.Message
 
-// Codec encodes and decodes Frames for transmission.
+// Codec encodes and decodes Messages for transmission.
 type Codec = core.Codec
 
 // JSONCodec is the default Codec. Frames are encoded as JSON text frames.

--- a/types.go
+++ b/types.go
@@ -8,7 +8,7 @@ type Message = core.Message
 // Codec encodes and decodes Messages for transmission.
 type Codec = core.Codec
 
-// JSONCodec is the default Codec. Frames are encoded as JSON text frames.
+// JSONCodec is the default Codec. Messages are encoded as JSON text frames.
 var JSONCodec = core.JSONCodec
 
 // WebSocket message type constants.


### PR DESCRIPTION
## Summary

Release v0.11.0 — rename `Frame` to `Message`, `FrameDropped` to `MessageDropped`, and `Codec.FrameType()` to `Codec.WireType()`, following upstream core v0.6.0.

## Related issues

- Relates to wspulse/.github#34
- Relates to #38

## Changes

- **BREAKING**: `Frame` type alias → `Message`
- **BREAKING**: `MetricsCollector.FrameDropped` → `MessageDropped`
- **BREAKING**: `Codec.FrameType()` → `Codec.WireType()`
- All internal usages, tests, docs, README updated
- Bumped `wspulse/core` to v0.6.0

See CHANGELOG.md for full details.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue