### PR TITLE
chore: ignore worktree(s) directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,6 +305,10 @@ yarn-error.log*
 .DS_Store
 Thumbs.db
 
+# Local git worktrees
+**/worktree/
+**/worktrees/
+
 # Misc
 *.pem
 .mx/


### PR DESCRIPTION
## Summary

Add `**/worktree/` and `**/worktrees/` to `.gitignore` so local git worktree directories (e.g. `.claude/worktrees/`, `.mx/<feature>/worktree/`) stop showing up under untracked files.

## Changes

- `.gitignore`: new "Local git worktrees" section with the two glob patterns above.

## Checklist

### Required

- [x] `make check` passes — gitignore-only change, no Go code touched
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR