### PR TITLE
Release v0.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,6 +305,10 @@ yarn-error.log*
 .DS_Store
 Thumbs.db
 
+# Local git worktrees
+**/worktree/
+**/worktrees/
+
 # Misc
 *.pem
 .mx/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Server-initiated close frames now carry cause-specific data instead of
+  always emitting `(1000, "")`. New mapping:
+  | Cause | Code | Reason string |
+  |-------|------|---------------|
+  | Application `Connection.Close()` | `1000` | `""` (unchanged) |
+  | `Hub.Kick` | `1000` | `"kicked"` |
+  | Duplicate connection id displaces a session | `1000` | `"duplicate connection id"` |
+  | Hub shutdown (`Hub.Close`) | `1001` | `"server shutting down"` |
+
+  Wire-visible to clients but strictly more informative — clients that
+  ignored the close frame data are unaffected. `core.StatusCode` is
+  unchanged; the cause information lives in the reason string. (#58)
+
+### Fixed
+
+- `writePump` no longer skips the graceful close frame when the pump
+  context is cancelled by hub shutdown. Previously the priority-exit at
+  the top of the write loop fired on both reconnect-swap (correct) and
+  shutdown (incorrect, the close frame was dropped). The priority-exit
+  now triggers only when the session itself is still alive, so shutdown
+  always emits the close frame.
+
 ## [0.11.2] - 2026-05-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,19 @@
 ### Changed
 
 - Server-initiated close frames now carry cause-specific data instead of
-  always emitting `(1000, "")`. New mapping:
-  | Cause | Code | Reason string |
-  |-------|------|---------------|
-  | Application `Connection.Close()` | `1000` | `""` (unchanged) |
-  | `Hub.Kick` | `1000` | `"kicked"` |
-  | Duplicate connection id displaces a session | `1000` | `"duplicate connection id"` |
-  | Hub shutdown (`Hub.Close`) | `1001` | `"server shutting down"` |
+  always emitting `(1000, "")`. Wire-visible to clients but strictly more
+  informative — clients that ignored the close frame data are unaffected.
+  `core.StatusCode` is unchanged; the cause information lives in the reason
+  string. (#58)
 
-  Wire-visible to clients but strictly more informative — clients that
-  ignored the close frame data are unaffected. `core.StatusCode` is
-  unchanged; the cause information lives in the reason string. (#58)
+  New mapping:
+
+  | Cause                                       | Code   | Reason string             |
+  |---------------------------------------------|--------|---------------------------|
+  | Application `Connection.Close()`            | `1000` | `""` (unchanged)          |
+  | `Hub.Kick`                                  | `1000` | `"kicked"`                |
+  | Duplicate connection id displaces a session | `1000` | `"duplicate connection id"` |
+  | Hub shutdown (`Hub.Close`)                  | `1001` | `"server shutting down"`  |
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-02
+
 ### Changed
 
 - Server-initiated close frames now carry cause-specific data instead of
@@ -21,12 +23,18 @@
 
 ### Fixed
 
-- `writePump` no longer skips the graceful close frame when the pump
-  context is cancelled by hub shutdown. Previously the priority-exit at
-  the top of the write loop fired on both reconnect-swap (correct) and
-  shutdown (incorrect, the close frame was dropped). The priority-exit
-  now triggers only when the session itself is still alive, so shutdown
-  always emits the close frame.
+- `writePump` no longer drops the graceful close frame when hub shutdown
+  cancels `pumpCtx`. Two exit paths were affected:
+  1. The priority-exit at the top of the write loop fired on both
+     reconnect-swap (correct) and shutdown (incorrect). It is now narrowed
+     to fire only while the session is still alive.
+  2. The `trans.Write` context-error branch returned without sending a
+     close frame, so any shutdown that raced an in-flight write silently
+     dropped the frame. Real TCP writes can block for up to `writeTimeout`,
+     so this race was reachable in production.
+
+  Both paths now share an `emitCloseFrameOnShutdown` helper that sends the
+  configured `(code, reason)` whenever `session.done` is closed.
 
 ## [0.11.2] - 2026-05-02
 
@@ -253,7 +261,8 @@
 - `Server.Close` is synchronous — returns only after all goroutines exit
 - Data race in `attachWS` buffer length check
 
-[Unreleased]: https://github.com/wspulse/hub/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/wspulse/hub/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/wspulse/hub/compare/v0.11.2...v0.12.0
 [0.11.2]: https://github.com/wspulse/hub/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/wspulse/hub/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/wspulse/hub/compare/v0.10.0...v0.11.0

--- a/close_frame_test.go
+++ b/close_frame_test.go
@@ -79,8 +79,10 @@ func TestHub_Close_EmitsServerShuttingDown(t *testing.T) {
 	// session with the (StatusGoingAway, "server shutting down") frame.
 	srv.Close()
 
-	// writePump's graceful close-frame send happens before the deferred
-	// CloseNow that fires closeCh.
+	// closeCh fires as soon as either trans.Close or trans.CloseNow runs.
+	// writePump's graceful trans.Close happens first on the shutdown path,
+	// so by the time we wake here the (code, reason) call is already
+	// recorded.
 	<-mt.closeCh
 
 	calls := mt.CloseCalls()

--- a/close_frame_test.go
+++ b/close_frame_test.go
@@ -1,0 +1,43 @@
+package wspulse_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "github.com/wspulse/core"
+	wspulse "github.com/wspulse/hub"
+)
+
+// ── Hub shutdown close frame ────────────────────────────────────────────────
+
+// TestHub_Close_EmitsServerShuttingDown verifies that when the hub shuts down,
+// each session's writePump emits a close frame with StatusGoingAway (1001) and
+// the reason "server shutting down" — distinct from the default
+// (StatusNormalClosure, "") used for application-initiated session close.
+func TestHub_Close_EmitsServerShuttingDown(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 1)
+	srv := wspulse.NewHub(
+		acceptAll,
+		wspulse.WithOnConnect(func(_ wspulse.Connection) {
+			connected <- struct{}{}
+		}),
+	)
+
+	mt := injectAndWait(t, srv, "conn-1", "room-1", connected)
+
+	// hub.Close() drives the heart shutdown path, which should close every
+	// session with the (StatusGoingAway, "server shutting down") frame.
+	srv.Close()
+
+	// writePump's graceful close-frame send happens before the deferred
+	// CloseNow that fires closeCh.
+	<-mt.closeCh
+
+	calls := mt.CloseCalls()
+	require.Len(t, calls, 1, "expected exactly one Close(code, reason) call from writePump shutdown path")
+	assert.Equal(t, core.StatusGoingAway, calls[0].code)
+	assert.Equal(t, "server shutting down", calls[0].reason)
+}

--- a/close_frame_test.go
+++ b/close_frame_test.go
@@ -41,3 +41,36 @@ func TestHub_Close_EmitsServerShuttingDown(t *testing.T) {
 	assert.Equal(t, core.StatusGoingAway, calls[0].code)
 	assert.Equal(t, "server shutting down", calls[0].reason)
 }
+
+// ── Kick close frame ────────────────────────────────────────────────────────
+
+// TestHub_Kick_EmitsKickedReason verifies that Hub.Kick produces a close
+// frame with StatusNormalClosure (1000) and the reason "kicked", letting
+// clients distinguish a server-initiated kick from a routine close on the
+// wire.
+func TestHub_Kick_EmitsKickedReason(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 1)
+	disconnected := make(chan struct{}, 1)
+	srv := wspulse.NewHub(
+		acceptAll,
+		wspulse.WithOnConnect(func(_ wspulse.Connection) {
+			connected <- struct{}{}
+		}),
+		wspulse.WithOnDisconnect(func(_ wspulse.Connection, _ error) {
+			disconnected <- struct{}{}
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	mt := injectAndWait(t, srv, "kick-target", "room-1", connected)
+
+	require.NoError(t, srv.Kick("kick-target"))
+	requireReceive(t, disconnected)
+	<-mt.closeCh
+
+	calls := mt.CloseCalls()
+	require.Len(t, calls, 1, "expected exactly one Close(code, reason) call from kick path")
+	assert.Equal(t, core.StatusNormalClosure, calls[0].code)
+	assert.Equal(t, "kicked", calls[0].reason)
+}

--- a/close_frame_test.go
+++ b/close_frame_test.go
@@ -74,3 +74,43 @@ func TestHub_Kick_EmitsKickedReason(t *testing.T) {
 	assert.Equal(t, core.StatusNormalClosure, calls[0].code)
 	assert.Equal(t, "kicked", calls[0].reason)
 }
+
+// ── Duplicate conn_id close frame ───────────────────────────────────────────
+
+// TestHub_DuplicateConnectionID_EmitsDuplicateReason verifies that when a
+// second InjectTransport arrives with the same connectionID, the displaced
+// session's close frame is (1000, "duplicate connection id") rather than
+// the generic (1000, ""). This lets clients distinguish "your session was
+// taken over by a same-id login" from a routine close.
+func TestHub_DuplicateConnectionID_EmitsDuplicateReason(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 2)
+	disconnected := make(chan struct{}, 1)
+	srv := wspulse.NewHub(
+		acceptAll,
+		wspulse.WithOnConnect(func(_ wspulse.Connection) {
+			connected <- struct{}{}
+		}),
+		wspulse.WithOnDisconnect(func(_ wspulse.Connection, _ error) {
+			disconnected <- struct{}{}
+		}),
+	)
+	t.Cleanup(srv.Close)
+
+	first := injectAndWait(t, srv, "dup-conn", "room-1", connected)
+
+	// Second registration with the same conn_id evicts the first.
+	second := newMockTransport()
+	wspulse.InjectTransport(srv, "dup-conn", "room-1", second)
+	requireReceive(t, connected) // second session connects
+
+	// The first session is the one being kicked out — wait for its
+	// onDisconnect, then for its writePump to emit the close frame.
+	requireReceive(t, disconnected)
+	<-first.closeCh
+
+	calls := first.CloseCalls()
+	require.Len(t, calls, 1, "expected exactly one Close(code, reason) call from duplicate path")
+	assert.Equal(t, core.StatusNormalClosure, calls[0].code)
+	assert.Equal(t, "duplicate connection id", calls[0].reason)
+}

--- a/close_frame_test.go
+++ b/close_frame_test.go
@@ -26,6 +26,9 @@ func TestHub_Close_DuringBlockedWrite_StillEmitsServerShuttingDown(t *testing.T)
 			connected <- struct{}{}
 		}),
 	)
+	// Safety net: srv.Close is also called explicitly below, but goleak
+	// would flag a leak if any assertion above the explicit Close fails.
+	t.Cleanup(srv.Close)
 
 	mt := newMockTransport()
 	// Make Write block until ctx done, simulating a slow TCP write.
@@ -66,6 +69,9 @@ func TestHub_Close_EmitsServerShuttingDown(t *testing.T) {
 			connected <- struct{}{}
 		}),
 	)
+	// Safety net: srv.Close is also called explicitly below, but goleak
+	// would flag a leak if any assertion above the explicit Close fails.
+	t.Cleanup(srv.Close)
 
 	mt := injectAndWait(t, srv, "conn-1", "room-1", connected)
 

--- a/close_frame_test.go
+++ b/close_frame_test.go
@@ -12,6 +12,47 @@ import (
 
 // ── Hub shutdown close frame ────────────────────────────────────────────────
 
+// TestHub_Close_DuringBlockedWrite_StillEmitsServerShuttingDown verifies
+// the close-frame is still emitted when shutdown cancels pumpCtx while
+// writePump is blocked inside trans.Write. Real WebSocket writes can block
+// for up to writeTimeout on slow TCP, and without explicit handling in the
+// write-error path the close frame is silently dropped.
+func TestHub_Close_DuringBlockedWrite_StillEmitsServerShuttingDown(t *testing.T) {
+	t.Parallel()
+	connected := make(chan struct{}, 1)
+	srv := wspulse.NewHub(
+		acceptAll,
+		wspulse.WithOnConnect(func(_ wspulse.Connection) {
+			connected <- struct{}{}
+		}),
+	)
+
+	mt := newMockTransport()
+	// Make Write block until ctx done, simulating a slow TCP write.
+	mt.SetBlockWrite(true)
+	wspulse.InjectTransport(srv, "conn-1", "room-1", mt)
+	requireReceive(t, connected)
+
+	// Push a message so writePump dequeues and enters trans.Write.
+	conns := srv.GetConnections("room-1")
+	require.Len(t, conns, 1)
+	require.NoError(t, conns[0].Send(wspulse.Message{Event: "trigger", Payload: []byte(`"x"`)}))
+
+	// Synchronise: wait until writePump is actually inside trans.Write.
+	<-mt.writeEnteredCh
+
+	// Hub shutdown — pumpCtx cancels, trans.Write returns ctx.Err().
+	// The close-frame send must still happen on the way out.
+	srv.Close()
+
+	<-mt.closeCh
+
+	calls := mt.CloseCalls()
+	require.Len(t, calls, 1, "shutdown during blocked write must still emit close frame")
+	assert.Equal(t, core.StatusGoingAway, calls[0].code)
+	assert.Equal(t, "server shutting down", calls[0].reason)
+}
+
 // TestHub_Close_EmitsServerShuttingDown verifies that when the hub shuts down,
 // each session's writePump emits a close frame with StatusGoingAway (1001) and
 // the reason "server shutting down" — distinct from the default

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -50,8 +50,12 @@ first (e.g. by `detachWS` during resume), the bridge exits without effect.
   sends a `transportDied` message to the heart and exits.
 - `writePump` owns the TCP connection close call: it calls `transport.CloseNow()`
   on exit (via defer) to ensure the underlying socket is always released.
-  On graceful shutdown (`ctx.Done()`), it first sends a close frame via
-  `transport.Close(StatusNormalClosure, "")`.
+  On graceful shutdown (`session.done` closed), it first sends a close frame
+  via `transport.Close(code, reason)`. The `(code, reason)` pair is set on
+  the session by `closeWith` before `done` is closed; see §4 for the full
+  mapping. On reconnect-swap (`pumpCtx` cancelled while `session.done` is
+  still open) writePump exits via the priority-exit path without sending a
+  close frame — the replacement pump owns the connection.
 - `pingPump` sends periodic Pings with a `writeTimeout` timeout. On failure it
   fires the `HeartbeatFailed` metric and calls `transport.CloseNow()` to force the
   transport closed, causing `readPump` to detect the error and signal the heart.
@@ -160,12 +164,33 @@ cause (close frame / network drop / ping timeout)
   → readPump: Read(ctx) returns error, sends transportDiedMessage to heart
   → heart: if resumeWindow > 0 → suspend session (start grace timer)
            if resumeWindow == 0 → remove session, call OnDisconnect
-  → session.Close() (via closeOnce): closes done channel
+  → session.closeWith(code, reason) (via closeOnce): records the
+      close-frame data on the session and closes the done channel
   → bridge goroutine: <-done → pumpCancel()
-  → writePump: ctx.Done() fires, sends Close(StatusNormalClosure) only
-    on session shutdown (s.done closed); skipped on reconnect swap
-    and if the priority-exit path runs first. Defers CloseNow()
+  → writePump: send queue closed → err branch → reads (code, reason)
+      under s.mu and emits transport.Close(code, reason). Defers CloseNow().
+      Skipped on reconnect-swap (pumpCtx cancelled while session.done is
+      still open) so the replacement pump owns the connection.
 ```
+
+### Close-frame mapping
+
+The `(code, reason)` pair the writePump emits depends on which
+`DisconnectReason` triggered the teardown:
+
+| Cause                                 | Code   | Reason string             |
+| ------------------------------------- | ------ | ------------------------- |
+| Application `Connection.Close()`      | `1000` | `""`                      |
+| `Hub.Kick`                            | `1000` | `"kicked"`                |
+| Duplicate `connectionID` displacement | `1000` | `"duplicate connection id"` |
+| Hub shutdown (`Hub.Close`)            | `1001` | `"server shutting down"`  |
+| Resume grace window expired           | n/a    | n/a — transport already dead |
+
+Application semantics live in the reason string; `core.StatusCode` is left
+to RFC 6455 protocol-level usage. The mapping is applied by
+`heart.disconnectSession` (which routes through `closeFrameForReason`) and
+`heart.shutdown` (which sets `(StatusGoingAway, "server shutting down")`
+inline).
 
 Explicit teardown via `Hub.Kick(connectionID)` takes a different path — the
 kick request is routed through the heart to ensure serialized cleanup (see

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -187,10 +187,10 @@ The `(code, reason)` pair the writePump emits depends on which
 | Resume grace window expired           | n/a    | n/a — transport already dead |
 
 Application semantics live in the reason string; `core.StatusCode` is left
-to RFC 6455 protocol-level usage. The mapping is applied by
-`heart.disconnectSession` (which routes through `closeFrameForReason`) and
-`heart.shutdown` (which sets `(StatusGoingAway, "server shutting down")`
-inline).
+to RFC 6455 protocol-level usage. Both heart-driven teardown sites —
+`heart.disconnectSession` and `heart.shutdown` — resolve the close frame
+through `closeFrameForReason`, which is the single source of truth for the
+mapping.
 
 Explicit teardown via `Hub.Kick(connectionID)` takes a different path — the
 kick request is routed through the heart to ensure serialized cleanup (see

--- a/heart.go
+++ b/heart.go
@@ -473,15 +473,18 @@ func (h *heart) disconnectSession(target *session, err error, reason DisconnectR
 // closeFrameForReason returns the WebSocket close code and reason string the
 // hub should emit when terminating a session for the given DisconnectReason.
 //
-// All cases use StatusNormalClosure (1000) — the server is performing an
-// intentional close. The reason string carries the diagnostic context.
-// StatusGoingAway is reserved for hub shutdown, applied directly in shutdown().
+// Most cases use StatusNormalClosure (1000) — the server is performing an
+// intentional close, and the reason string carries the diagnostic context.
+// DisconnectHubClose is the exception: hub shutdown maps to StatusGoingAway
+// (1001), which is RFC 6455 §7.4.1's exact use of "server going away".
 func closeFrameForReason(reason DisconnectReason) (core.StatusCode, string) {
 	switch reason {
 	case DisconnectKick:
 		return core.StatusNormalClosure, "kicked"
 	case DisconnectDuplicate:
 		return core.StatusNormalClosure, "duplicate connection id"
+	case DisconnectHubClose:
+		return core.StatusGoingAway, "server shutting down"
 	default:
 		// DisconnectNormal, DisconnectGraceExpired, and any future reason
 		// that has not been assigned a dedicated string fall through to
@@ -537,13 +540,12 @@ func (h *heart) shutdown() {
 	}
 	var closedInfos []closedInfo
 	var destroyedRooms []string
+	hubCloseCode, hubCloseReason := closeFrameForReason(DisconnectHubClose)
 	for roomID, room := range h.rooms {
 		for _, target := range room {
 			target.cancelGraceTimer()
 			closedInfos = append(closedInfos, closedInfo{target.roomID, target.id, time.Since(target.connectedAt)})
-			// Close with StatusGoingAway so the close frame carries
-			// "server shutting down" — RFC 6455 §7.4.1's exact use of 1001.
-			_ = target.closeWith(core.StatusGoingAway, "server shutting down")
+			_ = target.closeWith(hubCloseCode, hubCloseReason)
 			disconnected = append(disconnected, target)
 		}
 		destroyedRooms = append(destroyedRooms, roomID)

--- a/heart.go
+++ b/heart.go
@@ -8,6 +8,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/maxence2997/carousel"
+
+	core "github.com/wspulse/core"
 )
 
 // ── internal message types ────────────────────────────────────────────────────
@@ -176,7 +178,13 @@ func (h *heart) handleRegister(message registerMessage) {
 		done:        make(chan struct{}),
 		state:       stateConnected,
 		connectedAt: time.Now(),
-		config:      h.config,
+		// Default close-frame data; overridden by closeWith on heart-driven
+		// teardown paths (kick, hub shutdown, duplicate conn_id). Set
+		// explicitly so the readPump heart-shutdown safety-net path (which
+		// closes s.done directly via closeOnce without going through
+		// closeWith) still leaves writePump with a valid close code.
+		closeCode: core.StatusNormalClosure,
+		config:    h.config,
 	}
 	if h.config.resumeWindow > 0 {
 		newSession.resumeBuffer = carousel.NewRingBuffer[[]byte](h.config.sendBufferSize)
@@ -505,7 +513,9 @@ func (h *heart) shutdown() {
 		for _, target := range room {
 			target.cancelGraceTimer()
 			closedInfos = append(closedInfos, closedInfo{target.roomID, target.id, time.Since(target.connectedAt)})
-			_ = target.Close()
+			// Close with StatusGoingAway so the close frame carries
+			// "server shutting down" — RFC 6455 §7.4.1's exact use of 1001.
+			_ = target.closeWith(core.StatusGoingAway, "server shutting down")
 			disconnected = append(disconnected, target)
 		}
 		destroyedRooms = append(destroyedRooms, roomID)

--- a/heart.go
+++ b/heart.go
@@ -456,10 +456,11 @@ func (h *heart) handleBroadcast(message broadcastMessage) {
 // onDisconnect. Safe to call even if Close() was already called externally
 // (closeOnce makes it idempotent).
 //
-// The DisconnectReason is mapped to a (code, reason) pair so the close frame
-// the remote peer receives carries cause information. Reasons that emerge
-// outside this code path (hub shutdown via shutdown()) supply their own
-// (code, reason) directly to closeWith.
+// The DisconnectReason is mapped to a (code, reason) pair via
+// closeFrameForReason so the close frame the remote peer receives carries
+// cause information. Hub shutdown (handled in shutdown()) uses the same
+// mapper, so closeFrameForReason is the single source of truth for the
+// close-frame mapping.
 func (h *heart) disconnectSession(target *session, err error, reason DisconnectReason) {
 	h.removeSession(target)
 	h.config.metrics.ConnectionClosed(target.roomID, target.id, time.Since(target.connectedAt), reason)

--- a/heart.go
+++ b/heart.go
@@ -480,6 +480,8 @@ func closeFrameForReason(reason DisconnectReason) (core.StatusCode, string) {
 	switch reason {
 	case DisconnectKick:
 		return core.StatusNormalClosure, "kicked"
+	case DisconnectDuplicate:
+		return core.StatusNormalClosure, "duplicate connection id"
 	default:
 		// DisconnectNormal, DisconnectGraceExpired, and any future reason
 		// that has not been assigned a dedicated string fall through to

--- a/heart.go
+++ b/heart.go
@@ -455,12 +455,38 @@ func (h *heart) handleBroadcast(message broadcastMessage) {
 // disconnectSession removes the session from heart maps, closes it, and fires
 // onDisconnect. Safe to call even if Close() was already called externally
 // (closeOnce makes it idempotent).
+//
+// The DisconnectReason is mapped to a (code, reason) pair so the close frame
+// the remote peer receives carries cause information. Reasons that emerge
+// outside this code path (hub shutdown via shutdown()) supply their own
+// (code, reason) directly to closeWith.
 func (h *heart) disconnectSession(target *session, err error, reason DisconnectReason) {
 	h.removeSession(target)
 	h.config.metrics.ConnectionClosed(target.roomID, target.id, time.Since(target.connectedAt), reason)
-	_ = target.Close()
+	code, frameReason := closeFrameForReason(reason)
+	_ = target.closeWith(code, frameReason)
 	if fn := h.config.onDisconnect; fn != nil {
 		go fn(target, err)
+	}
+}
+
+// closeFrameForReason returns the WebSocket close code and reason string the
+// hub should emit when terminating a session for the given DisconnectReason.
+//
+// All cases use StatusNormalClosure (1000) — the server is performing an
+// intentional close. The reason string carries the diagnostic context.
+// StatusGoingAway is reserved for hub shutdown, applied directly in shutdown().
+func closeFrameForReason(reason DisconnectReason) (core.StatusCode, string) {
+	switch reason {
+	case DisconnectKick:
+		return core.StatusNormalClosure, "kicked"
+	default:
+		// DisconnectNormal, DisconnectGraceExpired, and any future reason
+		// that has not been assigned a dedicated string fall through to
+		// the wire-level default. DisconnectGraceExpired never reaches a
+		// live transport (the WebSocket already died before the grace
+		// timer fired), so the value is moot for that case.
+		return core.StatusNormalClosure, ""
 	}
 }
 

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -17,15 +17,18 @@ import (
 // need to control ping liveness call SetPingHandler to provide a custom
 // function. This ensures tests never depend on real timeouts.
 type mockTransport struct {
-	readCh    chan readResult // test → readPump: inject messages or errors
-	writeCh   chan writeCall  // writePump → test: capture outbound messages
-	closeCh   chan struct{}   // closed once on Close() or CloseNow()
-	closeOnce sync.Once
+	readCh           chan readResult // test → readPump: inject messages or errors
+	writeCh          chan writeCall  // writePump → test: capture outbound messages
+	closeCh          chan struct{}   // closed once on Close() or CloseNow()
+	writeEnteredCh   chan struct{}   // closed the first time Write is entered
+	closeOnce        sync.Once
+	writeEnteredOnce sync.Once
 
 	mu          sync.Mutex
 	readLimit   int64
 	closed      bool
 	blockClose  bool                            // true = CloseNow / Close are no-ops
+	blockWrite  bool                            // true = Write blocks until ctx done
 	pingHandler func(ctx context.Context) error // nil = always succeed
 	closeCalls  []closeCall                     // recorded Close(code, reason) calls
 }
@@ -50,9 +53,10 @@ type writeCall struct {
 
 func newMockTransport() *mockTransport {
 	return &mockTransport{
-		readCh:  make(chan readResult, 16),
-		writeCh: make(chan writeCall, 256),
-		closeCh: make(chan struct{}),
+		readCh:         make(chan readResult, 16),
+		writeCh:        make(chan writeCall, 256),
+		closeCh:        make(chan struct{}),
+		writeEnteredCh: make(chan struct{}),
 	}
 }
 
@@ -79,7 +83,20 @@ func (m *mockTransport) Write(ctx context.Context, messageType core.MessageType,
 		m.mu.Unlock()
 		return net.ErrClosed
 	}
+	blockWrite := m.blockWrite
 	m.mu.Unlock()
+
+	// Signal that writePump has entered Write. Lets tests synchronise on
+	// the moment writePump is actually inside trans.Write before they
+	// trigger shutdown — no time.Sleep needed.
+	m.writeEnteredOnce.Do(func() { close(m.writeEnteredCh) })
+
+	if blockWrite {
+		// Simulate a slow real-world TCP write that returns only when
+		// the deadline fires or the pump context is cancelled.
+		<-ctx.Done()
+		return ctx.Err()
+	}
 
 	copied := make([]byte, len(data))
 	copy(copied, data)
@@ -175,6 +192,16 @@ func (m *mockTransport) CloseNow() error {
 func (m *mockTransport) SetBlockClose(block bool) {
 	m.mu.Lock()
 	m.blockClose = block
+	m.mu.Unlock()
+}
+
+// SetBlockWrite makes Write block on ctx.Done instead of returning quickly.
+// Used to put writePump into a "stuck mid-write" state so tests can verify
+// behaviour when shutdown cancels pumpCtx during trans.Write — for example,
+// asserting the close frame is still emitted on the way out.
+func (m *mockTransport) SetBlockWrite(block bool) {
+	m.mu.Lock()
+	m.blockWrite = block
 	m.mu.Unlock()
 }
 

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -27,6 +27,14 @@ type mockTransport struct {
 	closed      bool
 	blockClose  bool                            // true = CloseNow / Close are no-ops
 	pingHandler func(ctx context.Context) error // nil = always succeed
+	closeCalls  []closeCall                     // recorded Close(code, reason) calls
+}
+
+// closeCall captures the arguments of one Close call so tests can assert
+// on the close frame the writePump emits.
+type closeCall struct {
+	code   core.StatusCode
+	reason string
 }
 
 type readResult struct {
@@ -110,8 +118,9 @@ func (m *mockTransport) SetReadLimit(limit int64) {
 	m.mu.Unlock()
 }
 
-func (m *mockTransport) Close(_ core.StatusCode, _ string) error {
+func (m *mockTransport) Close(code core.StatusCode, reason string) error {
 	m.mu.Lock()
+	m.closeCalls = append(m.closeCalls, closeCall{code: code, reason: reason})
 	if m.blockClose {
 		m.mu.Unlock()
 		return nil
@@ -124,6 +133,16 @@ func (m *mockTransport) Close(_ core.StatusCode, _ string) error {
 		close(m.closeCh)
 	})
 	return nil
+}
+
+// CloseCalls returns a copy of every Close(code, reason) call recorded so far.
+// Safe to call concurrently.
+func (m *mockTransport) CloseCalls() []closeCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]closeCall, len(m.closeCalls))
+	copy(out, m.closeCalls)
+	return out
 }
 
 func (m *mockTransport) CloseNow() error {

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -120,11 +120,11 @@ func (m *mockTransport) SetReadLimit(limit int64) {
 
 func (m *mockTransport) Close(code core.StatusCode, reason string) error {
 	m.mu.Lock()
-	m.closeCalls = append(m.closeCalls, closeCall{code: code, reason: reason})
 	if m.blockClose {
 		m.mu.Unlock()
 		return nil
 	}
+	m.closeCalls = append(m.closeCalls, closeCall{code: code, reason: reason})
 	m.mu.Unlock()
 	m.closeOnce.Do(func() {
 		m.mu.Lock()

--- a/session.go
+++ b/session.go
@@ -565,6 +565,30 @@ func isNormalClose(err error) bool {
 		code == websocket.StatusGoingAway
 }
 
+// emitCloseFrameOnShutdown sends the configured close frame to trans when
+// the session is shutting down (s.done closed). On reconnect-swap (ctx
+// cancelled but s.done still open) this is a no-op — the replacement pump
+// owns the connection.
+//
+// closeCode/closeReason are set inside the same closeOnce.Do body that
+// closes s.done, so observing s.done closed provides the happens-before
+// edge needed to read them safely. The s.mu acquisition mirrors closeWith's
+// write site for access-pattern consistency.
+//
+// All writePump exit paths that may run during shutdown call this helper so
+// the close frame is emitted regardless of which I/O step the pump was on
+// when shutdown fired.
+func (s *session) emitCloseFrameOnShutdown(trans transport) {
+	select {
+	case <-s.done:
+		s.mu.Lock()
+		code, reason := s.closeCode, s.closeReason
+		s.mu.Unlock()
+		_ = trans.Close(code, reason)
+	default:
+	}
+}
+
 // writePump drains the send channel on the transport. writePump is the sole
 // goroutine that writes application data to the transport. On exit it
 // force-closes the underlying connection so that readPump's Read unblocks.
@@ -604,22 +628,7 @@ func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan 
 				s.config.logger.Debug("wspulse: writePump stopping: context cancelled",
 					zap.String("conn_id", s.id))
 			}
-			// Send a graceful close frame only on session shutdown (s.done
-			// closed), not on reconnect swap where speed matters and the
-			// old transport may already be dead. closeCode/closeReason are
-			// set by closeWith before close(s.done), so the channel-receive
-			// already gives us the happens-before edge needed to read them
-			// safely. The s.mu acquisition below is defensive — it mirrors
-			// closeWith's write site so the access pattern stays consistent
-			// across the file.
-			select {
-			case <-s.done:
-				s.mu.Lock()
-				code, reason := s.closeCode, s.closeReason
-				s.mu.Unlock()
-				_ = trans.Close(code, reason)
-			default:
-			}
+			s.emitCloseFrameOnShutdown(trans)
 			return
 		}
 
@@ -630,6 +639,12 @@ func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan 
 			if ctx.Err() != nil {
 				s.config.logger.Debug("wspulse: writePump stopping: context cancelled",
 					zap.String("conn_id", s.id))
+				// Mirror the Pop-err branch above: shutdown can cancel
+				// pumpCtx while we are inside trans.Write (real TCP writes
+				// can block for up to writeTimeout). Without this, hub
+				// shutdown silently drops the close frame whenever
+				// writePump happens to be mid-write.
+				s.emitCloseFrameOnShutdown(trans)
 				return
 			}
 			s.config.logger.Warn("wspulse: write failed", zap.String("conn_id", s.id), zap.Error(err))

--- a/session.go
+++ b/session.go
@@ -608,8 +608,8 @@ func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan 
 		// (reconnect swap) — exit fast so the replacement pump owns the
 		// remaining messages in s.send. On full session shutdown (s.done
 		// closed) fall through so the err branch sends the graceful close
-		// frame; the send queue is closed in closeWith, so Pop returns
-		// promptly with ErrClosed.
+		// frame; closeWith closes both s.done and the send queue, so the
+		// next Pop returns promptly with either ErrClosed or ctx.Err().
 		select {
 		case <-ctx.Done():
 			select {

--- a/session.go
+++ b/session.go
@@ -573,10 +573,14 @@ func isNormalClose(err error) bool {
 // cancelled but s.done still open) this is a no-op — the replacement pump
 // owns the connection.
 //
-// closeCode/closeReason are set inside the same closeOnce.Do body that
-// closes s.done, so observing s.done closed provides the happens-before
-// edge needed to read them safely. The s.mu acquisition mirrors closeWith's
-// write site for access-pattern consistency.
+// closeCode/closeReason are normally set by closeWith inside the same
+// closeOnce.Do body that closes s.done; observing s.done closed gives the
+// happens-before edge needed to read them. The readPump heart-shutdown
+// safety-net path closes s.done directly via closeOnce.Do without going
+// through closeWith — when that race wins, the fields keep the constructor
+// defaults (StatusNormalClosure, "") set in handleRegister, which is still
+// a valid close frame. The s.mu acquisition mirrors closeWith's write site
+// for access-pattern consistency.
 //
 // All writePump exit paths that may run during shutdown call this helper so
 // the close frame is emitted regardless of which I/O step the pump was on

--- a/session.go
+++ b/session.go
@@ -71,7 +71,7 @@ type session struct {
 	send   *carousel.RingQueue[[]byte] // outbound message queue; shared across reconnects
 	done   chan struct{}               // closed once to signal session termination; guarded by closeOnce
 
-	mu           sync.Mutex                   // guards transport, pumpCancel, pumpDone, graceTimer, state, resumeBuffer, suspendEpoch
+	mu           sync.Mutex                   // guards transport, pumpCancel, pumpDone, graceTimer, state, resumeBuffer, suspendEpoch, closeCode, closeReason
 	transport    transport                    // current physical connection; nil when suspended
 	pumpCancel   context.CancelFunc           // cancels the current pump context
 	pumpDone     chan struct{}                // closed by writePump on exit
@@ -79,6 +79,8 @@ type session struct {
 	state        sessionState                 // current lifecycle state
 	resumeBuffer *carousel.RingBuffer[[]byte] // nil when resume is disabled
 	suspendEpoch uint64                       // monotonically increases on each detachWS; stale grace timers compare this
+	closeCode    core.StatusCode              // close-frame status code writePump emits on session shutdown; default StatusNormalClosure
+	closeReason  string                       // close-frame reason string writePump emits on session shutdown; default ""
 
 	connectedAt time.Time // session creation time; written once, read-only thereafter
 
@@ -184,23 +186,45 @@ func (s *session) cancelGraceTimer() {
 	s.mu.Unlock()
 }
 
-// Close initiates a graceful shutdown of the session.
-// Signals writePump to send a WebSocket close frame and stop.
+// Close initiates a graceful shutdown of the session and emits a close
+// frame with (StatusNormalClosure, "") to the remote peer. This is the
+// public Connection.Close() entry point used by application code.
+//
+// Heart-driven teardown paths use closeWith directly to encode the
+// disconnect cause (e.g. kick, hub shutdown, duplicate conn_id) into the
+// close frame's reason string.
+//
 // Safe to call multiple times; only the first call has effect.
+func (s *session) Close() error {
+	return s.closeWith(core.StatusNormalClosure, "")
+}
+
+// closeWith terminates the session and instructs writePump to emit a close
+// frame carrying the supplied (code, reason). Setting the close-frame
+// fields and closing s.done happen inside the same closeOnce.Do body, so
+// writePump (which only reads these fields after observing s.done closed)
+// is guaranteed to see them.
 //
 // Ordering note: heart-driven teardown (disconnectSession) always calls
-// cancelGraceTimer via removeSession before calling Close(). By the time
-// Close() acquires the lock, graceTimer is already nil, so timer.Reset(0)
+// cancelGraceTimer via removeSession before calling closeWith. By the time
+// closeWith acquires the lock, graceTimer is already nil, so timer.Reset(0)
 // is never invoked on that path. timer.Reset(0) is only reached when the
-// application calls Close() directly on a suspended session; in that case
-// it is intentional — it signals the heart via the existing graceExpired
-// channel without requiring a separate session-to-heart channel.
-func (s *session) Close() error {
+// application calls Close() (which routes through closeWith) directly on a
+// suspended session; in that case it is intentional — it signals the heart
+// via the existing graceExpired channel without requiring a separate
+// session-to-heart channel.
+//
+// Safe to call multiple times; only the first call has effect.
+func (s *session) closeWith(code core.StatusCode, reason string) error {
 	s.closeOnce.Do(func() {
 		s.config.logger.Debug("wspulse: session closing",
 			zap.String("conn_id", s.id),
+			zap.Int("close_code", int(code)),
+			zap.String("close_reason", reason),
 		)
 		s.mu.Lock()
+		s.closeCode = code
+		s.closeReason = reason
 		s.state = stateClosed
 		timer := s.graceTimer
 		s.graceTimer = nil
@@ -211,7 +235,7 @@ func (s *session) Close() error {
 
 		if timer != nil {
 			// Reset to 0 so handleGraceExpired fires immediately.
-			// See ordering note on Close() above.
+			// See ordering note on closeWith above.
 			timer.Reset(0)
 		}
 
@@ -553,12 +577,21 @@ func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan 
 	}()
 
 	for {
-		// Priority exit: if the context has been cancelled (reconnect swap),
-		// stop immediately to avoid consuming messages from s.send that
-		// the replacement pump should deliver.
+		// Priority exit: ctx cancelled while session is still alive
+		// (reconnect swap) — exit fast so the replacement pump owns the
+		// remaining messages in s.send. On full session shutdown (s.done
+		// closed) fall through so the err branch sends the graceful close
+		// frame; the send queue is closed in closeWith, so Pop returns
+		// promptly with ErrClosed.
 		select {
 		case <-ctx.Done():
-			return
+			select {
+			case <-s.done:
+				// Session shutting down — fall through to the standard
+				// exit path so writePump emits the configured close frame.
+			default:
+				return
+			}
 		default:
 		}
 
@@ -573,10 +606,15 @@ func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan 
 			}
 			// Send a graceful close frame only on session shutdown (s.done
 			// closed), not on reconnect swap where speed matters and the
-			// old transport may already be dead.
+			// old transport may already be dead. closeCode/closeReason are
+			// set by closeWith before close(s.done), so the channel-receive
+			// below establishes the happens-before edge for these reads.
 			select {
 			case <-s.done:
-				_ = trans.Close(core.StatusNormalClosure, "")
+				s.mu.Lock()
+				code, reason := s.closeCode, s.closeReason
+				s.mu.Unlock()
+				_ = trans.Close(code, reason)
 			default:
 			}
 			return

--- a/session.go
+++ b/session.go
@@ -186,13 +186,16 @@ func (s *session) cancelGraceTimer() {
 	s.mu.Unlock()
 }
 
-// Close initiates a graceful shutdown of the session and emits a close
-// frame with (StatusNormalClosure, "") to the remote peer. This is the
-// public Connection.Close() entry point used by application code.
+// Close initiates a graceful shutdown of the session. When a transport
+// is attached, writePump emits a close frame with (StatusNormalClosure,
+// "") to the remote peer before exiting. On a suspended session
+// (transport already dropped, awaiting resume) no close frame is sent —
+// the session is torn down via the heart's graceExpired path. This is
+// the public Connection.Close() entry point used by application code.
 //
 // Heart-driven teardown paths use closeWith directly to encode the
 // disconnect cause (e.g. kick, hub shutdown, duplicate conn_id) into the
-// close frame's reason string.
+// close frame's reason string when one is emitted.
 //
 // Safe to call multiple times; only the first call has effect.
 func (s *session) Close() error {

--- a/session.go
+++ b/session.go
@@ -608,7 +608,10 @@ func (s *session) writePump(ctx context.Context, trans transport, pumpDone chan 
 			// closed), not on reconnect swap where speed matters and the
 			// old transport may already be dead. closeCode/closeReason are
 			// set by closeWith before close(s.done), so the channel-receive
-			// below establishes the happens-before edge for these reads.
+			// already gives us the happens-before edge needed to read them
+			// safely. The s.mu acquisition below is defensive — it mirrors
+			// closeWith's write site so the access pattern stays consistent
+			// across the file.
 			select {
 			case <-s.done:
 				s.mu.Lock()


### PR DESCRIPTION
## Summary

Minor release v0.12.0. One feature PR landed on develop since v0.11.2: cause-specific WebSocket close frames on server-initiated disconnect. No public Go API changes — wire-level behaviour change only, strictly more informative for clients.

## Changes

One PR merged into develop since v0.11.2:

- #69 — feat: emit cause-specific close frames on disconnect. Threads `(close code, close reason)` through `session.closeWith` so the close frame the remote peer receives carries cause information:
  - `Hub.Kick` → `(1000, "kicked")`
  - duplicate conn_id displacement → `(1000, "duplicate connection id")`
  - `Hub.Close` (hub shutdown) → `(1001, "server shutting down")`
  - application `Connection.Close()` → `(1000, "")` (unchanged)

  Bundled writePump fixes for two close-frame-drop races during shutdown: priority-exit narrowed to reconnect-swap, and the `trans.Write` ctx-error branch now also emits the configured close frame via the shared `emitCloseFrameOnShutdown` helper. Closes #58.

CHANGELOG `[Unreleased]` block moved to `[0.12.0] - 2026-05-02` and compare links updated.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`) — verified on this branch
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] No public Go API changes — minor version bump (0.11.2 → 0.12.0) reflects the wire-visible behaviour change on close frames
- [x] Bug fix: includes regression tests for both writePump close-frame paths (`TestHub_Close_EmitsServerShuttingDown`, `TestHub_Close_DuringBlockedWrite_StillEmitsServerShuttingDown`)
- [x] Heart serialization not violated — `closeCode`/`closeReason` written by the heart goroutine inside `closeWith`, read by writePump after the `<-s.done` happens-before edge