### PR TITLE
release: v0.12.1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,47 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/instructions/**'
+  pull_request:
+    branches: [main, develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/instructions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Run benchmarks
+        run: make bench-ci
+
+      - name: Upload bench output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ github.sha }}
+          path: bench.txt
+          retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,3 +45,6 @@ jobs:
           name: bench-${{ github.sha }}
           path: bench.txt
           retention-days: 30
+          # If bench-ci failed before producing bench.txt, just warn so the
+          # original bench failure remains the primary signal.
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -312,3 +312,4 @@ Thumbs.db
 # Misc
 *.pem
 .mx/
+bench.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Benchmark harness with `make bench-ci`, `make bench-sync`, and a CI
+  workflow that uploads `bench.txt` as an artefact on every PR. See
+  `docs/bench.md` for the baseline numbers. (#71)
+
 ## [0.12.0] - 2026-05-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-05-18
+
 ### Added
 
 - Benchmark harness with `make bench-ci`, `make bench-sync`, and a CI
@@ -267,7 +269,8 @@
 - `Server.Close` is synchronous — returns only after all goroutines exit
 - Data race in `attachWS` buffer length check
 
-[Unreleased]: https://github.com/wspulse/hub/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/wspulse/hub/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/wspulse/hub/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/wspulse/hub/compare/v0.11.2...v0.12.0
 [0.11.2]: https://github.com/wspulse/hub/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/wspulse/hub/compare/v0.11.0...v0.11.1

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# bash gives us `set -o pipefail` and `trap` for the bench targets below;
+# all existing recipes are POSIX-compatible so this is safe.
+SHELL := /bin/bash
+
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 
 # Default target
@@ -17,14 +21,16 @@ bench: ## Run benchmarks with memory allocation stats
 	@go test -bench=. -benchmem -run=^$$ ./...
 
 bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
-	@outfile="$${BENCH_OUT:-bench.txt}"; \
+	@set -o pipefail; \
+		outfile="$${BENCH_OUT:-bench.txt}"; \
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 bench-sync: ## Refresh docs/bench.md from a fresh local benchmark run
-	@tmpfile="$$(mktemp)"; \
+	@set -e; \
+		tmpfile="$$(mktemp)"; \
+		trap 'rm -f "$$tmpfile"' EXIT; \
 		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
-		go run ./cmd/benchsync -input "$$tmpfile"; \
-		rm -f "$$tmpfile"
+		go run ./cmd/benchsync -input "$$tmpfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.
 bench-sync: ## Refresh docs/bench.md from a fresh local benchmark run
 	@echo "── running benchmarks ──"
 	@set -e; \
-		tmpfile="$$(mktemp)"; \
+		tmpfile="$$(mktemp -t wspulse-benchsync.XXXXXX)"; \
 		trap 'rm -f "$$tmpfile"' EXIT; \
 		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile"; \
 		echo "── refreshing docs/bench.md ──"; \

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,14 @@ bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 bench-sync: ## Refresh docs/bench.md from a fresh local benchmark run
+	@echo "── running benchmarks ──"
 	@set -e; \
 		tmpfile="$$(mktemp)"; \
 		trap 'rm -f "$$tmpfile"' EXIT; \
-		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
-		go run ./cmd/benchsync -input "$$tmpfile"
+		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile"; \
+		echo "── refreshing docs/bench.md ──"; \
+		go run ./cmd/benchsync -input "$$tmpfile"; \
+		echo "── done ──"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-# bash gives us `set -o pipefail` and `trap` for the bench targets below;
-# all existing recipes are POSIX-compatible so this is safe.
-SHELL := /bin/bash
+# bash (looked up via PATH, not hardcoded to /bin/bash) gives us
+# `set -o pipefail` and `trap` for the bench targets below; all existing
+# recipes are POSIX-compatible so this is safe.
+SHELL := bash
 
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-cover bench lint fmt check tidy deps clean
+.PHONY: help test test-cover bench bench-ci lint fmt check tidy deps clean
 
 # Default target
 help: ## Show available commands
@@ -15,6 +15,10 @@ test-cover: ## Run all tests with coverage report
 
 bench: ## Run benchmarks with memory allocation stats
 	@go test -bench=. -benchmem -run=^$$ ./...
+
+bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
+	@outfile="$${BENCH_OUT:-bench.txt}"; \
+		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-cover bench bench-ci lint fmt check tidy deps clean
+.PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 
 # Default target
 help: ## Show available commands
@@ -19,6 +19,12 @@ bench: ## Run benchmarks with memory allocation stats
 bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
 	@outfile="$${BENCH_OUT:-bench.txt}"; \
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
+
+bench-sync: ## Refresh docs/bench.md from a fresh local benchmark run
+	@tmpfile="$$(mktemp)"; \
+		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
+		go run ./cmd/benchsync -input "$$tmpfile"; \
+		rm -f "$$tmpfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-# bash (looked up via PATH, not hardcoded to /bin/bash) gives us
-# `set -o pipefail` and `trap` for the bench targets below; all existing
-# recipes are POSIX-compatible so this is safe.
-SHELL := bash
-
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
+
+# bench-ci and bench-sync use bash for `set -o pipefail` and `trap`; all
+# other recipes stay POSIX-compatible so they run in any /bin/sh.
+bench-ci bench-sync: SHELL := bash
 
 # Default target
 help: ## Show available commands

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -1,0 +1,278 @@
+// Command benchsync regenerates the benchmark tables in docs from a fresh
+// `go test -bench` output file. It parses the standard Go benchmark format,
+// emits one markdown row per known benchmark name, and replaces the table
+// inside a managed marker block in the target document.
+//
+// Run via `make bench-sync` from the repo root.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var benchLinePattern = regexp.MustCompile(`^(Benchmark\S+?)(?:-\d+)?\s+\d+\s+(\S+)\s+ns/op\s+(\S+)\s+B/op\s+(\S+)\s+allocs/op$`)
+
+type benchEnv struct {
+	GOOS   string
+	GOARCH string
+	CPU    string
+}
+
+type benchReport struct {
+	Env     benchEnv
+	Results map[string]benchResult
+}
+
+type benchResult struct {
+	NSPerOp     string
+	BPerOp      string
+	AllocsPerOp string
+}
+
+type benchRow struct {
+	Name  string
+	Label string
+}
+
+type benchTarget struct {
+	Path       string
+	MarkerName string
+	Rows       []benchRow
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("benchsync", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	root := fs.String("root", ".", "repository root")
+	inputPath := fs.String("input", "", "path to benchmark output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *inputPath == "" {
+		return fmt.Errorf("input benchmark file is required")
+	}
+
+	input, err := os.ReadFile(*inputPath)
+	if err != nil {
+		return fmt.Errorf("read benchmark input: %w", err)
+	}
+
+	report, err := parseBenchResults(input)
+	if err != nil {
+		return err
+	}
+
+	for _, target := range defaultTargets(*root) {
+		markdown, err := os.ReadFile(target.Path)
+		if err != nil {
+			return fmt.Errorf("read markdown %s: %w", target.Path, err)
+		}
+
+		table, err := renderBenchTable(target.Rows, report)
+		if err != nil {
+			return err
+		}
+
+		updated, err := replaceManagedBlock(markdown, target.MarkerName, table)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", target.Path, err)
+		}
+
+		if err := os.WriteFile(target.Path, updated, 0o644); err != nil {
+			return fmt.Errorf("write markdown %s: %w", target.Path, err)
+		}
+	}
+
+	return nil
+}
+
+// defaultTargets enumerates the benchmark tables maintained in docs.
+// Each row maps a Go benchmark name (with sub-benchmark path, no -GOMAXPROCS
+// suffix) to its display label. Add new rows here when adding new benchmark
+// cases to keep docs/bench.md in sync.
+func defaultTargets(root string) []benchTarget {
+	var broadcastRows []benchRow
+	for _, room := range []int{1, 10, 100, 1000} {
+		for _, ms := range []struct {
+			label string
+			tag   string
+		}{
+			{"64 B", "64B"},
+			{"1 KiB", "1KiB"},
+			{"16 KiB", "16KiB"},
+		} {
+			broadcastRows = append(broadcastRows, benchRow{
+				Name:  fmt.Sprintf("BenchmarkBroadcast/room=%d/messageSize=%s", room, ms.tag),
+				Label: fmt.Sprintf("Broadcast (room=%d, %s)", room, ms.label),
+			})
+		}
+	}
+
+	rows := append([]benchRow{}, broadcastRows...)
+	rows = append(rows,
+		benchRow{Name: "BenchmarkSend/messageSize=64B", Label: "Send (64 B)"},
+		benchRow{Name: "BenchmarkSend/messageSize=1KiB", Label: "Send (1 KiB)"},
+		benchRow{Name: "BenchmarkSend/messageSize=16KiB", Label: "Send (16 KiB)"},
+		benchRow{Name: "BenchmarkEnqueue_DropOldest", Label: "Enqueue (drop-oldest)"},
+		benchRow{Name: "BenchmarkResumeBufferDrain", Label: "Resume buffer drain (256 msgs)"},
+	)
+
+	return []benchTarget{
+		{
+			Path:       filepath.Join(root, "docs", "bench.md"),
+			MarkerName: "benchsync:hub",
+			Rows:       rows,
+		},
+	}
+}
+
+func parseBenchResults(input []byte) (benchReport, error) {
+	report := benchReport{
+		Results: make(map[string]benchResult),
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(input))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "goos: "):
+			report.Env.GOOS = strings.TrimSpace(strings.TrimPrefix(line, "goos: "))
+			continue
+		case strings.HasPrefix(line, "goarch: "):
+			report.Env.GOARCH = strings.TrimSpace(strings.TrimPrefix(line, "goarch: "))
+			continue
+		case strings.HasPrefix(line, "cpu: "):
+			report.Env.CPU = strings.TrimSpace(strings.TrimPrefix(line, "cpu: "))
+			continue
+		}
+
+		matches := benchLinePattern.FindStringSubmatch(line)
+		if len(matches) == 0 {
+			continue
+		}
+
+		report.Results[matches[1]] = benchResult{
+			NSPerOp:     matches[2],
+			BPerOp:      matches[3],
+			AllocsPerOp: matches[4],
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return benchReport{}, fmt.Errorf("scan benchmark output: %w", err)
+	}
+	return report, nil
+}
+
+func renderBenchTable(rows []benchRow, report benchReport) (string, error) {
+	var out strings.Builder
+
+	if measurementLine := formatMeasurementLine(report.Env); measurementLine != "" {
+		out.WriteString(measurementLine)
+		out.WriteString("\n\n")
+	}
+
+	out.WriteString("| Operation | ns/op | B/op | allocs/op |\n")
+	out.WriteString("|---|---:|---:|---:|\n")
+
+	for _, row := range rows {
+		result, ok := report.Results[row.Name]
+		if !ok {
+			return "", fmt.Errorf("missing benchmark result for %s", row.Name)
+		}
+
+		if _, err := fmt.Fprintf(&out, "| `%s` | %s | %s | %s |\n",
+			row.Label,
+			formatMetric(result.NSPerOp),
+			formatMetric(result.BPerOp),
+			formatMetric(result.AllocsPerOp),
+		); err != nil {
+			return "", fmt.Errorf("render benchmark row %s: %w", row.Name, err)
+		}
+	}
+
+	return strings.TrimRight(out.String(), "\n"), nil
+}
+
+func formatMeasurementLine(env benchEnv) string {
+	platform := strings.Trim(strings.TrimSpace(env.GOOS)+"/"+strings.TrimSpace(env.GOARCH), "/")
+	switch {
+	case platform != "" && env.CPU != "":
+		return fmt.Sprintf("Measured on `%s` (`%s`).", platform, env.CPU)
+	case platform != "":
+		return fmt.Sprintf("Measured on `%s`.", platform)
+	case env.CPU != "":
+		return fmt.Sprintf("Measured on `%s`.", env.CPU)
+	default:
+		return ""
+	}
+}
+
+func replaceManagedBlock(markdown []byte, marker, content string) ([]byte, error) {
+	startMarker := "<!-- " + marker + ":start -->"
+	endMarker := "<!-- " + marker + ":end -->"
+
+	start := bytes.Index(markdown, []byte(startMarker))
+	if start == -1 {
+		return nil, fmt.Errorf("start marker not found: %s", marker)
+	}
+
+	end := bytes.Index(markdown[start:], []byte(endMarker))
+	if end == -1 {
+		return nil, fmt.Errorf("end marker not found: %s", marker)
+	}
+	end += start
+
+	var out bytes.Buffer
+	out.Write(markdown[:start+len(startMarker)])
+	out.WriteString("\n")
+	out.WriteString(content)
+	out.WriteString("\n")
+	out.Write(markdown[end:])
+	return out.Bytes(), nil
+}
+
+func formatMetric(value string) string {
+	if strings.Contains(value, ".") {
+		return strings.TrimRight(strings.TrimRight(value, "0"), ".")
+	}
+
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return value
+	}
+
+	sign := ""
+	if n < 0 {
+		sign = "-"
+		n = -n
+	}
+
+	raw := strconv.FormatInt(n, 10)
+	if len(raw) <= 3 {
+		return sign + raw
+	}
+
+	var parts []string
+	for len(raw) > 3 {
+		parts = append([]string{raw[len(raw)-3:]}, parts...)
+		raw = raw[:len(raw)-3]
+	}
+	parts = append([]string{raw}, parts...)
+	return sign + strings.Join(parts, ",")
+}

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -248,11 +248,12 @@ func replaceManagedBlock(markdown []byte, marker, content string) ([]byte, error
 }
 
 func formatMetric(value string) string {
-	if strings.Contains(value, ".") {
-		return strings.TrimRight(strings.TrimRight(value, "0"), ".")
+	intPart, fracPart, hasFrac := strings.Cut(value, ".")
+	if hasFrac {
+		fracPart = strings.TrimRight(fracPart, "0")
 	}
 
-	n, err := strconv.ParseInt(value, 10, 64)
+	n, err := strconv.ParseInt(intPart, 10, 64)
 	if err != nil {
 		return value
 	}
@@ -264,15 +265,22 @@ func formatMetric(value string) string {
 	}
 
 	raw := strconv.FormatInt(n, 10)
+	var grouped string
 	if len(raw) <= 3 {
-		return sign + raw
+		grouped = raw
+	} else {
+		var parts []string
+		for len(raw) > 3 {
+			parts = append([]string{raw[len(raw)-3:]}, parts...)
+			raw = raw[:len(raw)-3]
+		}
+		parts = append([]string{raw}, parts...)
+		grouped = strings.Join(parts, ",")
 	}
 
-	var parts []string
-	for len(raw) > 3 {
-		parts = append([]string{raw[len(raw)-3:]}, parts...)
-		raw = raw[:len(raw)-3]
+	out := sign + grouped
+	if hasFrac && fracPart != "" {
+		out += "." + fracPart
 	}
-	parts = append([]string{raw}, parts...)
-	return sign + strings.Join(parts, ",")
+	return out
 }

--- a/cmd/benchsync/main_test.go
+++ b/cmd/benchsync/main_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBenchResults_HubNames(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`
+goos: darwin
+goarch: arm64
+cpu: Apple M1 Max
+BenchmarkBroadcast/room=1/messageSize=64B-10            6140518       588.2 ns/op      337 B/op       4 allocs/op
+BenchmarkBroadcast/room=1000/messageSize=16KiB-10         48624     65118 ns/op    36829 B/op     286 allocs/op
+BenchmarkSend/messageSize=1KiB-10                       1000000      1234 ns/op      256 B/op       3 allocs/op
+BenchmarkResumeBufferDrain-10                                 3     42070 ns/op    26429 B/op     281 allocs/op
+PASS
+`)
+
+	got, err := parseBenchResults(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "darwin", got.Env.GOOS)
+	assert.Equal(t, "arm64", got.Env.GOARCH)
+	assert.Equal(t, "Apple M1 Max", got.Env.CPU)
+
+	// Sub-benchmark names with slashes and equals signs preserve correctly.
+	assert.Equal(t, "588.2", got.Results["BenchmarkBroadcast/room=1/messageSize=64B"].NSPerOp)
+	assert.Equal(t, "65118", got.Results["BenchmarkBroadcast/room=1000/messageSize=16KiB"].NSPerOp)
+	assert.Equal(t, "1234", got.Results["BenchmarkSend/messageSize=1KiB"].NSPerOp)
+
+	// Singleton benchmarks (no sub-name) parse correctly.
+	assert.Equal(t, "42070", got.Results["BenchmarkResumeBufferDrain"].NSPerOp)
+	assert.Equal(t, "26429", got.Results["BenchmarkResumeBufferDrain"].BPerOp)
+	assert.Equal(t, "281", got.Results["BenchmarkResumeBufferDrain"].AllocsPerOp)
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+
+	benchFile := filepath.Join(root, "bench.txt")
+	require.NoError(t, os.WriteFile(benchFile, []byte(`
+goos: darwin
+goarch: arm64
+cpu: Apple M1 Max
+BenchmarkBroadcast/room=1/messageSize=64B-10            6140518       588.2 ns/op      337 B/op       4 allocs/op
+BenchmarkBroadcast/room=1/messageSize=1KiB-10           5000000       720.0 ns/op      512 B/op       4 allocs/op
+BenchmarkBroadcast/room=1/messageSize=16KiB-10          1000000      4500   ns/op    16500 B/op       4 allocs/op
+BenchmarkBroadcast/room=10/messageSize=64B-10           4000000       780   ns/op      400 B/op       6 allocs/op
+BenchmarkBroadcast/room=10/messageSize=1KiB-10          3000000       950   ns/op      640 B/op       6 allocs/op
+BenchmarkBroadcast/room=10/messageSize=16KiB-10          800000      5800   ns/op    16700 B/op       6 allocs/op
+BenchmarkBroadcast/room=100/messageSize=64B-10          1000000      2100   ns/op      900 B/op      18 allocs/op
+BenchmarkBroadcast/room=100/messageSize=1KiB-10          800000      2700   ns/op     1200 B/op      18 allocs/op
+BenchmarkBroadcast/room=100/messageSize=16KiB-10         300000     12000   ns/op    18000 B/op      18 allocs/op
+BenchmarkBroadcast/room=1000/messageSize=64B-10          200000     12000   ns/op     6500 B/op     156 allocs/op
+BenchmarkBroadcast/room=1000/messageSize=1KiB-10         150000     17000   ns/op     8200 B/op     156 allocs/op
+BenchmarkBroadcast/room=1000/messageSize=16KiB-10         48624     65118   ns/op    36829 B/op     286 allocs/op
+BenchmarkSend/messageSize=64B-10                        2000000       420   ns/op      120 B/op       3 allocs/op
+BenchmarkSend/messageSize=1KiB-10                       1000000      1234   ns/op      256 B/op       3 allocs/op
+BenchmarkSend/messageSize=16KiB-10                       500000      3700   ns/op     2200 B/op       3 allocs/op
+BenchmarkEnqueue_DropOldest-10                          5000000       310   ns/op       80 B/op       2 allocs/op
+BenchmarkResumeBufferDrain-10                                 3     42070   ns/op    26429 B/op     281 allocs/op
+`), 0o644))
+
+	docPath := filepath.Join(root, "docs", "bench.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(strings.TrimSpace(`
+# Benchmarks
+
+<!-- benchsync:hub:start -->
+stale
+<!-- benchsync:hub:end -->
+`)+"\n"), 0o644))
+
+	require.NoError(t, run([]string{"-root", root, "-input", benchFile}))
+
+	got, err := os.ReadFile(docPath)
+	require.NoError(t, err)
+	doc := string(got)
+
+	assert.Contains(t, doc, "Measured on `darwin/arm64` (`Apple M1 Max`).")
+	assert.Contains(t, doc, "| `Broadcast (room=1, 64 B)` | 588.2 | 337 | 4 |")
+	assert.Contains(t, doc, "| `Broadcast (room=1000, 16 KiB)` | 65,118 | 36,829 | 286 |")
+	assert.Contains(t, doc, "| `Send (1 KiB)` | 1,234 | 256 | 3 |")
+	assert.Contains(t, doc, "| `Enqueue (drop-oldest)` | 310 | 80 | 2 |")
+	assert.Contains(t, doc, "| `Resume buffer drain (256 msgs)` | 42,070 | 26,429 | 281 |")
+}
+
+func TestRun_MissingResult(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+
+	// Bench output is missing several rows the target expects.
+	benchFile := filepath.Join(root, "bench.txt")
+	require.NoError(t, os.WriteFile(benchFile, []byte(`
+BenchmarkBroadcast/room=1/messageSize=64B-10  100 100 ns/op 0 B/op 0 allocs/op
+`), 0o644))
+
+	docPath := filepath.Join(root, "docs", "bench.md")
+	require.NoError(t, os.WriteFile(docPath, []byte("<!-- benchsync:hub:start -->\n<!-- benchsync:hub:end -->\n"), 0o644))
+
+	err := run([]string{"-root", root, "-input", benchFile})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing benchmark result")
+}
+
+func TestFormatMetric(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "107", formatMetric("107.0"))
+	assert.Equal(t, "5.59", formatMetric("5.590"))
+	assert.Equal(t, "1,626", formatMetric("1626"))
+	assert.Equal(t, "3.007", formatMetric("3.007"))
+	assert.Equal(t, "65,118", formatMetric("65118"))
+}

--- a/cmd/benchsync/main_test.go
+++ b/cmd/benchsync/main_test.go
@@ -123,4 +123,7 @@ func TestFormatMetric(t *testing.T) {
 	assert.Equal(t, "1,626", formatMetric("1626"))
 	assert.Equal(t, "3.007", formatMetric("3.007"))
 	assert.Equal(t, "65,118", formatMetric("65118"))
+	assert.Equal(t, "4,633.1", formatMetric("4633.1"))
+	assert.Equal(t, "1,234,567.89", formatMetric("1234567.89"))
+	assert.Equal(t, "-12,345.6", formatMetric("-12345.6"))
 }

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -1,9 +1,11 @@
 # Benchmarks
 
-Numbers below are the latest CI-published baseline for `wspulse/hub`. Regenerate
-locally with `make bench-sync`. The CI workflow uploads the raw `bench.txt`
-output as an artefact on every PR; download it from the run page if you need
-to compare specific numbers between branches.
+The table below is a checked-in baseline for `wspulse/hub`, last refreshed
+locally by a maintainer running `make bench-sync` on the hardware noted in
+the table. The CI workflow runs the same benchmarks on every PR and uploads
+the raw `bench.txt` as an artefact; download it from the run page if you
+need to compare specific numbers between branches. CI does not regenerate
+or commit this file.
 
 Variance between machines is expected — these baselines are a regression
 sanity check, not a portability claim. Single runs at `-benchtime=3s -count=1`

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -1,0 +1,44 @@
+# Benchmarks
+
+Numbers below are the latest CI-published baseline for `wspulse/hub`. Regenerate
+locally with `make bench-sync`. The CI workflow uploads the raw `bench.txt`
+output as an artefact on every PR; download it from the run page if you need
+to compare specific numbers between branches.
+
+Variance between machines is expected — these baselines are a regression
+sanity check, not a portability claim. Single runs at `-benchtime=3s -count=1`
+are noisy at the few-percent level; a one-off `bench-sync` is enough for
+order-of-magnitude regression detection but not micro-optimisation.
+
+The matrix covers:
+
+- `Broadcast` — fan-out cost across `room ∈ {1, 10, 100, 1000}` and
+  `messageSize ∈ {64 B, 1 KiB, 16 KiB}`.
+- `Send` — direct per-connection enqueue cost across the same payload sizes.
+- `Enqueue (drop-oldest)` — backpressure path when the send buffer is full.
+- `Resume buffer drain (256 msgs)` — heart-side cost of replaying a full
+  256-slot resume buffer into the send queue at reconnect time.
+
+<!-- benchsync:hub:start -->
+Measured on `darwin/arm64` (`Apple M1 Max`).
+
+| Operation | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `Broadcast (room=1, 64 B)` | 590.1 | 337 | 4 |
+| `Broadcast (room=1, 1 KiB)` | 4,456 | 1,394 | 4 |
+| `Broadcast (room=1, 16 KiB)` | 62,792 | 18,686 | 4 |
+| `Broadcast (room=10, 64 B)` | 1,003 | 944 | 13 |
+| `Broadcast (room=10, 1 KiB)` | 4,579 | 1,989 | 13 |
+| `Broadcast (room=10, 16 KiB)` | 63,093 | 19,274 | 13 |
+| `Broadcast (room=100, 64 B)` | 9,384 | 7,842 | 119 |
+| `Broadcast (room=100, 1 KiB)` | 6,937 | 7,352 | 96 |
+| `Broadcast (room=100, 16 KiB)` | 63,211 | 25,167 | 105 |
+| `Broadcast (room=1000, 64 B)` | 136,610 | 99,925 | 1,491 |
+| `Broadcast (room=1000, 1 KiB)` | 4,819 | 1,591 | 7 |
+| `Broadcast (room=1000, 16 KiB)` | 65,607 | 23,086 | 72 |
+| `Send (64 B)` | 521.7 | 353 | 5 |
+| `Send (1 KiB)` | 4,648 | 4,779 | 37 |
+| `Send (16 KiB)` | 74,246 | 61,737 | 96 |
+| `Enqueue (drop-oldest)` | 412.2 | 289 | 4 |
+| `Resume buffer drain (256 msgs)` | 28,747 | 32,343 | 372 |
+<!-- benchsync:hub:end -->

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -18,30 +18,34 @@ The matrix covers:
   `messageSize ∈ {64 B, 1 KiB, 16 KiB}`.
 - `Send` — direct per-connection enqueue cost across the same payload sizes.
 - `Enqueue (drop-oldest)` — backpressure path when the send buffer is full.
-- `Resume buffer drain (256 msgs)` — cost of replaying a full 256-slot
-  resume buffer into the send queue at reconnect time. The drain runs in
-  a transition goroutine spawned by `attachWS`, not on the heart loop.
+- `Resume buffer drain (256 msgs)` — per-cycle cost of staging a full
+  256-slot resume buffer (256 `ForcePush` calls) and draining it back into
+  the send queue (`RingBuffer.Drain` + 256 `ForceEnqueue`). The bench uses
+  the test-only `PrefillResumeBuffer` / `DrainResumeBuffer` hooks so that
+  transition-goroutine scheduling, `InjectTransport` routing, and codec
+  encode cost are excluded — regressions land directly on the buffer-copy
+  operations. Divide ns/op by 256 for amortised per-message cost.
 
 <!-- benchsync:hub:start -->
 Measured on `darwin/arm64` (`Apple M1 Max`).
 
 | Operation | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `Broadcast (room=1, 64 B)` | 590.1 | 337 | 4 |
-| `Broadcast (room=1, 1 KiB)` | 4,456 | 1,394 | 4 |
-| `Broadcast (room=1, 16 KiB)` | 62,792 | 18,686 | 4 |
-| `Broadcast (room=10, 64 B)` | 1,003 | 944 | 13 |
-| `Broadcast (room=10, 1 KiB)` | 4,579 | 1,989 | 13 |
-| `Broadcast (room=10, 16 KiB)` | 63,093 | 19,274 | 13 |
-| `Broadcast (room=100, 64 B)` | 9,384 | 7,842 | 119 |
-| `Broadcast (room=100, 1 KiB)` | 6,937 | 7,352 | 96 |
-| `Broadcast (room=100, 16 KiB)` | 63,211 | 25,167 | 105 |
-| `Broadcast (room=1000, 64 B)` | 136,610 | 99,925 | 1,491 |
-| `Broadcast (room=1000, 1 KiB)` | 4,819 | 1,591 | 7 |
-| `Broadcast (room=1000, 16 KiB)` | 65,607 | 23,086 | 72 |
-| `Send (64 B)` | 521.7 | 353 | 5 |
-| `Send (1 KiB)` | 4,648 | 4,779 | 37 |
-| `Send (16 KiB)` | 74,246 | 61,737 | 96 |
-| `Enqueue (drop-oldest)` | 412.2 | 289 | 4 |
-| `Resume buffer drain (256 msgs)` | 28,747 | 32,343 | 372 |
+| `Broadcast (room=1, 64 B)` | 631.8 | 337 | 4 |
+| `Broadcast (room=1, 1 KiB)` | 4,633 | 1,395 | 4 |
+| `Broadcast (room=1, 16 KiB)` | 64,090 | 18,686 | 4 |
+| `Broadcast (room=10, 64 B)` | 1,020 | 939 | 13 |
+| `Broadcast (room=10, 1 KiB)` | 4,580 | 1,988 | 13 |
+| `Broadcast (room=10, 16 KiB)` | 66,498 | 19,276 | 13 |
+| `Broadcast (room=100, 64 B)` | 10,016 | 7,922 | 120 |
+| `Broadcast (room=100, 1 KiB)` | 8,520 | 8,028 | 106 |
+| `Broadcast (room=100, 16 KiB)` | 72,170 | 25,141 | 104 |
+| `Broadcast (room=1000, 64 B)` | 304,390 | 134,025 | 1,949 |
+| `Broadcast (room=1000, 1 KiB)` | 6,001 | 1,779 | 10 |
+| `Broadcast (room=1000, 16 KiB)` | 66,870 | 23,705 | 81 |
+| `Send (64 B)` | 550.7 | 348 | 4 |
+| `Send (1 KiB)` | 4,795 | 4,706 | 36 |
+| `Send (16 KiB)` | 73,549 | 61,668 | 94 |
+| `Enqueue (drop-oldest)` | 396.8 | 289 | 4 |
+| `Resume buffer drain (256 msgs)` | 6,140 | 6,528 | 1 |
 <!-- benchsync:hub:end -->

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -18,8 +18,9 @@ The matrix covers:
   `messageSize ∈ {64 B, 1 KiB, 16 KiB}`.
 - `Send` — direct per-connection enqueue cost across the same payload sizes.
 - `Enqueue (drop-oldest)` — backpressure path when the send buffer is full.
-- `Resume buffer drain (256 msgs)` — heart-side cost of replaying a full
-  256-slot resume buffer into the send queue at reconnect time.
+- `Resume buffer drain (256 msgs)` — cost of replaying a full 256-slot
+  resume buffer into the send queue at reconnect time. The drain runs in
+  a transition goroutine spawned by `attachWS`, not on the heart loop.
 
 <!-- benchsync:hub:start -->
 Measured on `darwin/arm64` (`Apple M1 Max`).

--- a/export_test.go
+++ b/export_test.go
@@ -120,24 +120,30 @@ func DrainResumeBuffer(h Hub, connectionID string) (int, error) {
 	if !found {
 		return 0, fmt.Errorf("wspulse: DrainResumeBuffer: connection %q not found", connectionID)
 	}
+	// Mirror attachWS's drain loop locking exactly: hold sess.mu around
+	// each buffer.Drain() to serialise with concurrent Send() ForcePushes,
+	// release for the per-message ForceEnqueue (which is itself thread-safe),
+	// then re-acquire to check whether more arrived.
 	sess.mu.Lock()
-	buf := sess.resumeBuffer
-	sess.mu.Unlock()
-	if buf == nil {
+	if sess.resumeBuffer == nil {
+		sess.mu.Unlock()
 		return 0, fmt.Errorf("wspulse: DrainResumeBuffer: session %q has no resume buffer", connectionID)
 	}
 	drained := 0
 	for {
-		messages := buf.Drain()
+		messages := sess.resumeBuffer.Drain()
 		if len(messages) == 0 {
+			sess.mu.Unlock()
 			break
 		}
+		sess.mu.Unlock()
 		for _, data := range messages {
 			if _, err := sess.send.ForceEnqueue(data); err != nil {
 				return drained, fmt.Errorf("wspulse: DrainResumeBuffer: %w", err)
 			}
 			drained++
 		}
+		sess.mu.Lock()
 	}
 	return drained, nil
 }

--- a/export_test.go
+++ b/export_test.go
@@ -106,6 +106,18 @@ func PrefillResumeBuffer(h Hub, connectionID string, data []byte, count int) err
 //
 // Unlike attachWS, this helper does NOT flip the session state, so the
 // caller can re-prefill and re-drain repeatedly inside a benchmark loop.
+//
+// DRIFT WARNING: this is a hand-rolled replica of the drain loop inside
+// session.attachWS — they intentionally share the same locking pattern
+// (sess.mu held around each resumeBuffer.Drain, released for per-message
+// ForceEnqueue, re-acquired before the next iteration). If you change the
+// prod drain logic (additional metrics, different lock scope, batched
+// ForceEnqueue, etc.) you MUST update this helper to match, otherwise
+// BenchmarkResumeBufferDrain will silently measure stale semantics and
+// regression detection will misfire. The cleaner long-term fix is to
+// extract drainResumeBuffer into a session method and have both attachWS
+// and this helper call it (deferred — would need a callback parameter to
+// preserve the atomic empty-Drain + state-flip invariant in attachWS).
 func DrainResumeBuffer(h Hub, connectionID string) (int, error) {
 	if h == nil {
 		panic("wspulse: DrainResumeBuffer: hub must not be nil")

--- a/export_test.go
+++ b/export_test.go
@@ -64,6 +64,84 @@ func CloseSessionSendQueue(h Hub, connectionID string) error {
 	return nil
 }
 
+// PrefillResumeBuffer pushes count copies of data into the named session's
+// resume buffer via direct ForcePush, bypassing codec encoding and the
+// suspended-state check. Test-only — used by BenchmarkResumeBufferDrain to
+// stage a buffer for repeated drain measurements without paying encode cost
+// per iteration.
+//
+// The session's resumeBuffer must be non-nil (i.e. the hub was created
+// with WithResumeWindow > 0). Returns an error if the connection is not
+// found or the session has no resume buffer.
+func PrefillResumeBuffer(h Hub, connectionID string, data []byte, count int) error {
+	if h == nil {
+		panic("wspulse: PrefillResumeBuffer: hub must not be nil")
+	}
+	hub, ok := h.(*internalHub)
+	if !ok {
+		panic("wspulse: PrefillResumeBuffer: only works with hubs created by NewHub")
+	}
+	hub.heart.mu.RLock()
+	sess, found := hub.heart.connectionsByID[connectionID]
+	hub.heart.mu.RUnlock()
+	if !found {
+		return fmt.Errorf("wspulse: PrefillResumeBuffer: connection %q not found", connectionID)
+	}
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if sess.resumeBuffer == nil {
+		return fmt.Errorf("wspulse: PrefillResumeBuffer: session %q has no resume buffer", connectionID)
+	}
+	for i := 0; i < count; i++ {
+		sess.resumeBuffer.ForcePush(data)
+	}
+	return nil
+}
+
+// DrainResumeBuffer drains the named session's resume buffer back into its
+// send queue, mirroring the drain step that attachWS runs in its transition
+// goroutine. Returns the number of items drained. Test-only — paired with
+// PrefillResumeBuffer to bench the drain operation in isolation from the
+// transition-goroutine scheduling and InjectTransport routing overhead.
+//
+// Unlike attachWS, this helper does NOT flip the session state, so the
+// caller can re-prefill and re-drain repeatedly inside a benchmark loop.
+func DrainResumeBuffer(h Hub, connectionID string) (int, error) {
+	if h == nil {
+		panic("wspulse: DrainResumeBuffer: hub must not be nil")
+	}
+	hub, ok := h.(*internalHub)
+	if !ok {
+		panic("wspulse: DrainResumeBuffer: only works with hubs created by NewHub")
+	}
+	hub.heart.mu.RLock()
+	sess, found := hub.heart.connectionsByID[connectionID]
+	hub.heart.mu.RUnlock()
+	if !found {
+		return 0, fmt.Errorf("wspulse: DrainResumeBuffer: connection %q not found", connectionID)
+	}
+	sess.mu.Lock()
+	buf := sess.resumeBuffer
+	sess.mu.Unlock()
+	if buf == nil {
+		return 0, fmt.Errorf("wspulse: DrainResumeBuffer: session %q has no resume buffer", connectionID)
+	}
+	drained := 0
+	for {
+		messages := buf.Drain()
+		if len(messages) == 0 {
+			break
+		}
+		for _, data := range messages {
+			if _, err := sess.send.ForceEnqueue(data); err != nil {
+				return drained, fmt.Errorf("wspulse: DrainResumeBuffer: %w", err)
+			}
+			drained++
+		}
+	}
+	return drained, nil
+}
+
 // InjectTransport bypasses ServeHTTP and pushes a registerMessage directly
 // into the Hub's internal event loop. Test-only — allows component tests to
 // inject mock transports without HTTP upgrade.

--- a/export_test.go
+++ b/export_test.go
@@ -107,6 +107,15 @@ func PrefillResumeBuffer(h Hub, connectionID string, data []byte, count int) err
 // Unlike attachWS, this helper does NOT flip the session state, so the
 // caller can re-prefill and re-drain repeatedly inside a benchmark loop.
 //
+// INTENTIONAL DIVERGENCE: when sess.send.ForceEnqueue returns an error
+// (queue closed), attachWS logs and breaks — that path means the session
+// is terminating, which is a normal lifecycle event in production. Here
+// the helper returns the error instead. Inside a single-goroutine
+// benchmark a closed send queue is unexpected (teardown should not race
+// the iteration); surfacing it as an error makes BenchmarkResumeBufferDrain
+// fail loudly rather than silently report a partial drain count and
+// distort measurements.
+//
 // DRIFT WARNING: this is a hand-rolled replica of the drain loop inside
 // session.attachWS — they intentionally share the same locking pattern
 // (sess.mu held around each resumeBuffer.Drain, released for per-message

--- a/export_test.go
+++ b/export_test.go
@@ -135,15 +135,19 @@ func DrainResumeBuffer(h Hub, connectionID string) (int, error) {
 	// Mirror attachWS's drain loop locking exactly: hold sess.mu around
 	// each buffer.Drain() to serialise with concurrent Send() ForcePushes,
 	// release for the per-message ForceEnqueue (which is itself thread-safe),
-	// then re-acquire to check whether more arrived.
+	// then re-acquire to check whether more arrived. Capture the buffer
+	// pointer once under the initial lock — attachWS does the same so a
+	// concurrent closeWith (which nils sess.resumeBuffer) cannot nil-panic
+	// a drain in flight.
 	sess.mu.Lock()
-	if sess.resumeBuffer == nil {
+	buffer := sess.resumeBuffer
+	if buffer == nil {
 		sess.mu.Unlock()
 		return 0, fmt.Errorf("wspulse: DrainResumeBuffer: session %q has no resume buffer", connectionID)
 	}
 	drained := 0
 	for {
-		messages := sess.resumeBuffer.Drain()
+		messages := buffer.Drain()
 		if len(messages) == 0 {
 			sess.mu.Unlock()
 			break

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -239,11 +239,14 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 }
 
 // BenchmarkResumeBufferDrain measures the cost of one suspend → fill resume
-// buffer → reconnect cycle. The drain itself runs inside the heart goroutine
-// during attachWS, before onTransportRestore fires. The bench uses mock
-// transports (via InjectTransport) to avoid WebSocket dial overhead, so the
-// measurement is dominated by buffer drain + heart scheduling rather than
-// network noise.
+// buffer → reconnect cycle. attachWS spawns a transition goroutine that
+// waits for the old pumps to exit, drains resumeBuffer into the send queue,
+// and then starts new pumps; the heart event loop is not blocked for the
+// drain itself. onTransportRestore fires after the transition goroutine
+// completes the drain, so the bench measures the full transition (cost
+// dominated by buffer drain + goroutine scheduling rather than network
+// noise — mock transports via InjectTransport eliminate WebSocket dial
+// overhead).
 //
 // The fill phase (256 broadcasts to a suspended session) is bench-internal
 // setup and is excluded from the timed region via b.StopTimer/StartTimer.

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -289,10 +289,21 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 	)
 	b.Cleanup(srv.Close)
 
+	// waitFor blocks on ch with a timeout; if the callback that fills ch
+	// fails to fire (regression in InjectTransport / resume wiring), the
+	// bench fails fast instead of hanging until the CI job timeout.
+	waitFor := func(ch <-chan struct{}, what string) {
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			b.Fatalf("timed out waiting for %s", what)
+		}
+	}
+
 	// Initial connect.
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, connectionID, roomID, mt)
-	<-connected
+	waitFor(connected, "initial connect")
 
 	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(64)}
 
@@ -302,7 +313,7 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 		b.StopTimer()
 		// Drop the current transport, transitioning the session to suspended.
 		mt.InjectError(errors.New("bench: transport closed"))
-		<-dropped
+		waitFor(dropped, "transport drop")
 
 		// Fill the resume buffer to capacity. Broadcasts during suspension
 		// land in resumeBuffer (drop-oldest at full).
@@ -318,6 +329,6 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 		mt = newMockTransport()
 		b.StartTimer()
 		wspulse.InjectTransport(srv, connectionID, roomID, mt)
-		<-restored
+		waitFor(restored, "transport restore")
 	}
 }

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -112,8 +112,7 @@ func benchBroadcast(b *testing.B, roomSize, payloadSize int) {
 
 	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(payloadSize)}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := srv.Broadcast("bench-room", msg); err != nil {
 			b.Fatalf("Broadcast: %v", err)
 		}
@@ -176,8 +175,7 @@ func benchSend(b *testing.B, payloadSize int) {
 
 	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(payloadSize)}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		// ErrSendBufferFull is expected at benchmark speed — the drain
 		// goroutine cannot keep up with the enqueue rate. The benchmark
 		// measures raw encode+enqueue cost including both paths.
@@ -230,26 +228,34 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := srv.Broadcast("bench-room", msg); err != nil {
 			b.Fatalf("Broadcast failed: %v", err)
 		}
 	}
 }
 
-// BenchmarkResumeBufferDrain measures the cost of one suspend → fill resume
-// buffer → reconnect cycle. attachWS spawns a transition goroutine that
-// waits for the old pumps to exit, drains resumeBuffer into the send queue,
-// and then starts new pumps; the heart event loop is not blocked for the
-// drain itself. onTransportRestore fires after the transition goroutine
-// completes the drain, so the bench measures the full transition (cost
-// dominated by buffer drain + goroutine scheduling rather than network
-// noise — mock transports via InjectTransport eliminate WebSocket dial
-// overhead).
+// BenchmarkResumeBufferDrain measures the per-cycle cost of staging a full
+// 256-slot resume buffer and draining it back into the send queue. The
+// drain logic is what attachWS runs in its transition goroutine when a
+// suspended session reconnects; this bench isolates that path from
+// transition-goroutine scheduling, InjectTransport routing, and codec
+// encode cost so regressions land directly on the buffer-copy operations.
 //
-// The fill phase (256 broadcasts to a suspended session) is bench-internal
-// setup and is excluded from the timed region via b.StopTimer/StartTimer.
+// Each iteration:
+//   - PrefillResumeBuffer: 256 direct ForcePush calls into resumeBuffer.
+//   - DrainResumeBuffer: pops every entry via RingBuffer.Drain and
+//     re-enqueues each onto the send queue with ForceEnqueue.
+//
+// Setup (one-time): connect a mock transport, drop it so the session is in
+// stateSuspended (which is what makes resumeBuffer the fill target), and
+// pre-encode a representative payload so the loop pays zero codec cost.
+//
+// Reported ns/op covers (256 ForcePush + 256 ForceEnqueue) per cycle —
+// divide by 256 to get amortised per-message cost. The original "full
+// reconnect cycle" measurement is intentionally not captured here; it
+// rolled in goroutine scheduling and channel routing that obscured drain
+// regressions.
 func BenchmarkResumeBufferDrain(b *testing.B) {
 	const (
 		bufferSize   = 256
@@ -257,19 +263,16 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 		roomID       = "bench-room"
 	)
 
-	// Buffered=1 + non-blocking send: each iteration produces exactly one
-	// drop and one restore, both consumed before the next iteration starts.
-	// Sizing channels b.N+1 is wasteful and signals the wrong sync model;
-	// the pattern below matches the other benches in this file.
 	connected := make(chan struct{}, 1)
 	dropped := make(chan struct{}, 1)
-	restored := make(chan struct{}, 1)
 
 	srv := wspulse.NewHub(
 		func(r *http.Request) (string, string, error) {
 			return roomID, connectionID, nil
 		},
-		wspulse.WithResumeWindow(30*time.Second),
+		// resumeWindow only needs to outlast the bench setup; the drain
+		// hooks bypass the grace timer entirely.
+		wspulse.WithResumeWindow(time.Hour),
 		wspulse.WithSendBufferSize(bufferSize),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
 			select {
@@ -283,18 +286,9 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 			default:
 			}
 		}),
-		wspulse.WithOnTransportRestore(func(_ wspulse.Connection) {
-			select {
-			case restored <- struct{}{}:
-			default:
-			}
-		}),
 	)
 	b.Cleanup(srv.Close)
 
-	// waitFor blocks on ch with a timeout; if the callback that fills ch
-	// fails to fire (regression in InjectTransport / resume wiring), the
-	// bench fails fast instead of hanging until the CI job timeout.
 	waitFor := func(ch <-chan struct{}, what string) {
 		select {
 		case <-ch:
@@ -303,35 +297,33 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 		}
 	}
 
-	// Initial connect.
+	// Setup: connect, then drop the transport so the session enters
+	// stateSuspended. PrefillResumeBuffer requires the session to exist;
+	// DrainResumeBuffer doesn't care about state but won't run if the
+	// session has already been removed.
 	mt := newMockTransport()
 	wspulse.InjectTransport(srv, connectionID, roomID, mt)
 	waitFor(connected, "initial connect")
+	mt.InjectError(errors.New("bench: transport closed"))
+	waitFor(dropped, "transport drop")
 
-	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(64)}
+	// Pre-encode the bench payload once; the inner loop reuses the
+	// encoded bytes via ForcePush, so no codec cost is included.
+	encoded, err := wspulse.JSONCodec.Encode(wspulse.Message{
+		Event:   "bench",
+		Payload: jsonPayload(64),
+	})
+	if err != nil {
+		b.Fatalf("JSONCodec.Encode setup: %v", err)
+	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		// Drop the current transport, transitioning the session to suspended.
-		mt.InjectError(errors.New("bench: transport closed"))
-		waitFor(dropped, "transport drop")
-
-		// Fill the resume buffer to capacity. Broadcasts during suspension
-		// land in resumeBuffer (drop-oldest at full).
-		for j := 0; j < bufferSize; j++ {
-			if err := srv.Broadcast(roomID, msg); err != nil {
-				b.Fatalf("Broadcast(fill): %v", err)
-			}
+	for b.Loop() {
+		if err := wspulse.PrefillResumeBuffer(srv, connectionID, encoded, bufferSize); err != nil {
+			b.Fatalf("PrefillResumeBuffer: %v", err)
 		}
-
-		// Reconnect: a fresh mock transport triggers attachWS, which spawns
-		// a transition goroutine to drain resumeBuffer back into the send
-		// queue. onTransportRestore fires after the drain completes.
-		mt = newMockTransport()
-		b.StartTimer()
-		wspulse.InjectTransport(srv, connectionID, roomID, mt)
-		waitFor(restored, "transport restore")
+		if _, err := wspulse.DrainResumeBuffer(srv, connectionID); err != nil {
+			b.Fatalf("DrainResumeBuffer: %v", err)
+		}
 	}
 }

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -254,9 +254,13 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 		roomID       = "bench-room"
 	)
 
+	// Buffered=1 + non-blocking send: each iteration produces exactly one
+	// drop and one restore, both consumed before the next iteration starts.
+	// Sizing channels b.N+1 is wasteful and signals the wrong sync model;
+	// the pattern below matches the other benches in this file.
 	connected := make(chan struct{}, 1)
-	dropped := make(chan struct{}, b.N+1)
-	restored := make(chan struct{}, b.N+1)
+	dropped := make(chan struct{}, 1)
+	restored := make(chan struct{}, 1)
 
 	srv := wspulse.NewHub(
 		func(r *http.Request) (string, string, error) {
@@ -265,13 +269,22 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 		wspulse.WithResumeWindow(30*time.Second),
 		wspulse.WithSendBufferSize(bufferSize),
 		wspulse.WithOnConnect(func(_ wspulse.Connection) {
-			connected <- struct{}{}
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
 		}),
 		wspulse.WithOnTransportDrop(func(_ wspulse.Connection, _ error) {
-			dropped <- struct{}{}
+			select {
+			case dropped <- struct{}{}:
+			default:
+			}
 		}),
 		wspulse.WithOnTransportRestore(func(_ wspulse.Connection) {
-			restored <- struct{}{}
+			select {
+			case restored <- struct{}{}:
+			default:
+			}
 		}),
 	)
 	b.Cleanup(srv.Close)

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -326,9 +326,9 @@ func BenchmarkResumeBufferDrain(b *testing.B) {
 			}
 		}
 
-		// Reconnect: a fresh mock transport triggers attachWS, which drains
-		// resumeBuffer back into the send queue inside the heart goroutine
-		// before onTransportRestore fires.
+		// Reconnect: a fresh mock transport triggers attachWS, which spawns
+		// a transition goroutine to drain resumeBuffer back into the send
+		// queue. onTransportRestore fires after the drain completes.
 		mt = newMockTransport()
 		b.StartTimer()
 		wspulse.InjectTransport(srv, connectionID, roomID, mt)

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -2,6 +2,7 @@ package wspulse_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -49,15 +50,38 @@ func dialN(b *testing.B, srv wspulse.Hub, n int) (*httptest.Server, []*websocket
 	return ts, conns
 }
 
+// jsonPayload returns a valid JSON string payload with total byte length size.
+// size includes the surrounding quotes; minimum is 2 (an empty JSON string).
+func jsonPayload(size int) []byte {
+	if size < 2 {
+		size = 2
+	}
+	return []byte(`"` + strings.Repeat("x", size-2) + `"`)
+}
+
+// messageSizes is the standard payload size matrix shared by Broadcast and Send
+// benchmarks. Values match the workspace bench-harness plan.
+var messageSizes = []struct {
+	label string
+	size  int
+}{
+	{"64B", 64},
+	{"1KiB", 1024},
+	{"16KiB", 16 * 1024},
+}
+
 func BenchmarkBroadcast(b *testing.B) {
-	for _, roomSize := range []int{1, 10, 100} {
-		b.Run(fmt.Sprintf("room_%d", roomSize), func(b *testing.B) {
-			benchBroadcast(b, roomSize)
-		})
+	for _, roomSize := range []int{1, 10, 100, 1000} {
+		for _, ms := range messageSizes {
+			name := fmt.Sprintf("room=%d/messageSize=%s", roomSize, ms.label)
+			b.Run(name, func(b *testing.B) {
+				benchBroadcast(b, roomSize, ms.size)
+			})
+		}
 	}
 }
 
-func benchBroadcast(b *testing.B, roomSize int) {
+func benchBroadcast(b *testing.B, roomSize, payloadSize int) {
 	connected := make(chan struct{}, roomSize)
 	srv := wspulse.NewHub(
 		benchAcceptN(),
@@ -86,7 +110,7 @@ func benchBroadcast(b *testing.B, roomSize int) {
 		}
 	}
 
-	msg := wspulse.Message{Event: "bench", Payload: []byte(`{"v":1}`)}
+	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(payloadSize)}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -97,6 +121,14 @@ func benchBroadcast(b *testing.B, roomSize int) {
 }
 
 func BenchmarkSend(b *testing.B) {
+	for _, ms := range messageSizes {
+		b.Run(fmt.Sprintf("messageSize=%s", ms.label), func(b *testing.B) {
+			benchSend(b, ms.size)
+		})
+	}
+}
+
+func benchSend(b *testing.B, payloadSize int) {
 	var conn wspulse.Connection
 	connected := make(chan struct{}, 1)
 	srv := wspulse.NewHub(
@@ -142,7 +174,7 @@ func BenchmarkSend(b *testing.B) {
 		}
 	}()
 
-	msg := wspulse.Message{Event: "bench", Payload: []byte(`{"v":1}`)}
+	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(payloadSize)}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -203,5 +235,76 @@ func BenchmarkEnqueue_DropOldest(b *testing.B) {
 		if err := srv.Broadcast("bench-room", msg); err != nil {
 			b.Fatalf("Broadcast failed: %v", err)
 		}
+	}
+}
+
+// BenchmarkResumeBufferDrain measures the cost of one suspend → fill resume
+// buffer → reconnect cycle. The drain itself runs inside the heart goroutine
+// during attachWS, before onTransportRestore fires. The bench uses mock
+// transports (via InjectTransport) to avoid WebSocket dial overhead, so the
+// measurement is dominated by buffer drain + heart scheduling rather than
+// network noise.
+//
+// The fill phase (256 broadcasts to a suspended session) is bench-internal
+// setup and is excluded from the timed region via b.StopTimer/StartTimer.
+func BenchmarkResumeBufferDrain(b *testing.B) {
+	const (
+		bufferSize   = 256
+		connectionID = "bench-conn"
+		roomID       = "bench-room"
+	)
+
+	connected := make(chan struct{}, 1)
+	dropped := make(chan struct{}, b.N+1)
+	restored := make(chan struct{}, b.N+1)
+
+	srv := wspulse.NewHub(
+		func(r *http.Request) (string, string, error) {
+			return roomID, connectionID, nil
+		},
+		wspulse.WithResumeWindow(30*time.Second),
+		wspulse.WithSendBufferSize(bufferSize),
+		wspulse.WithOnConnect(func(_ wspulse.Connection) {
+			connected <- struct{}{}
+		}),
+		wspulse.WithOnTransportDrop(func(_ wspulse.Connection, _ error) {
+			dropped <- struct{}{}
+		}),
+		wspulse.WithOnTransportRestore(func(_ wspulse.Connection) {
+			restored <- struct{}{}
+		}),
+	)
+	b.Cleanup(srv.Close)
+
+	// Initial connect.
+	mt := newMockTransport()
+	wspulse.InjectTransport(srv, connectionID, roomID, mt)
+	<-connected
+
+	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(64)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		// Drop the current transport, transitioning the session to suspended.
+		mt.InjectError(errors.New("bench: transport closed"))
+		<-dropped
+
+		// Fill the resume buffer to capacity. Broadcasts during suspension
+		// land in resumeBuffer (drop-oldest at full).
+		for j := 0; j < bufferSize; j++ {
+			if err := srv.Broadcast(roomID, msg); err != nil {
+				b.Fatalf("Broadcast(fill): %v", err)
+			}
+		}
+
+		// Reconnect: a fresh mock transport triggers attachWS, which drains
+		// resumeBuffer back into the send queue inside the heart goroutine
+		// before onTransportRestore fires.
+		mt = newMockTransport()
+		b.StartTimer()
+		wspulse.InjectTransport(srv, connectionID, roomID, mt)
+		<-restored
 	}
 }


### PR DESCRIPTION
## Summary

Release v0.12.1 — adds a checked-in benchmark harness for `hub`. Pure dev tooling: no public API or runtime behaviour changes.

## Related issues

Closes #71

## Changes

- Extend bench matrix with `BenchmarkSend`, `BenchmarkBroadcast`, and `BenchmarkResumeBufferDrain` in `server_bench_test.go`; gate channel waits with `waitFor` (`select` + `time.After` + `b.Fatalf`) to fail fast instead of hanging on CI
- Add `make bench-ci` and `make bench-sync` targets (portable `mktemp` template, bash scoped per-target, streamed output, failure propagation, `set -o pipefail`)
- Add `cmd/benchsync/` table generator that regenerates `docs/bench.md` from a fresh bench run
- Add `.github/workflows/benchmark.yml` uploading `bench.txt` as an artefact on every PR (`if-no-files-found: warn` so bench failures stay the primary signal)
- Check in first-iteration baseline at `docs/bench.md` (post-`b.Loop` and resume-drain redesign)
- Add `export_test.go` `DrainResumeBuffer` / `PrefillResumeBuffer` hooks; mirror `attachWS`'s drain-loop locking and load-once buffer pointer for race-detector cleanliness
- Promote `[Unreleased]` to `[0.12.1] - 2026-05-18` in CHANGELOG; add v0.12.0...v0.12.1 compare link

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Performance-sensitive change: benchmark included (this PR _is_ the benchmark harness; baseline at `docs/bench.md`)